### PR TITLE
feat: implement Stage 3 history panel

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2542,6 +2542,7 @@ dependencies = [
 name = "popmark"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,3 +19,4 @@ tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,16 +1,52 @@
+use chrono::Local;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_dialog::{DialogExt, FilePath};
 
-fn draft_path(app: &AppHandle) -> Result<PathBuf, String> {
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HistoryEntry {
+    pub id: String,
+    pub timestamp: String,
+    pub title_preview: String,
+}
+
+fn app_data_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
         .path()
         .app_data_dir()
         .map_err(|e: tauri::Error| e.to_string())?;
     fs::create_dir_all(&dir).map_err(|e: std::io::Error| e.to_string())?;
-    Ok(dir.join("draft.md"))
+    Ok(dir)
+}
+
+fn draft_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app_data_dir(app)?.join("draft.md"))
+}
+
+fn history_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app_data_dir(app)?.join("history");
+    fs::create_dir_all(&dir).map_err(|e: std::io::Error| e.to_string())?;
+    Ok(dir)
+}
+
+fn extract_title_preview(content: &str) -> String {
+    let first_line = content
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("");
+    // Strip leading Markdown heading markers
+    let stripped = first_line.trim_start_matches('#').trim();
+    if stripped.is_empty() {
+        return "(empty)".to_string();
+    }
+    if stripped.chars().count() > 60 {
+        stripped.chars().take(60).collect::<String>() + "…"
+    } else {
+        stripped.to_string()
+    }
 }
 
 #[tauri::command]
@@ -31,15 +67,79 @@ pub fn save_draft(app: AppHandle, content: String) -> Result<(), String> {
 
 #[tauri::command]
 pub fn copy_and_close(app: AppHandle, content: String) -> Result<(), String> {
-    app.clipboard().write_text(content).map_err(|e| e.to_string())?;
+    // 1. Copy to clipboard
+    app.clipboard()
+        .write_text(content.clone())
+        .map_err(|e| e.to_string())?;
+
+    // 2. Save to history
+    let now = Local::now();
+    let id = now.format("%Y-%m-%dT%H-%M-%S").to_string();
+    let timestamp = now.format("%Y-%m-%dT%H:%M:%S").to_string();
+    let title_preview = extract_title_preview(&content);
+
+    let history = history_dir(&app)?;
+    let file_path = history.join(format!("{}.md", id));
+    fs::write(&file_path, &content).map_err(|e| e.to_string())?;
+
+    // 3. Update index.json (prepend new entry to maintain reverse-chronological order)
+    let index_path = history.join("index.json");
+    let mut entries: Vec<HistoryEntry> = if index_path.exists() {
+        let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    entries.insert(
+        0,
+        HistoryEntry {
+            id,
+            timestamp,
+            title_preview,
+        },
+    );
+    let json = serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())?;
+    fs::write(&index_path, json).map_err(|e| e.to_string())?;
+
+    // 4. Clear draft
+    let draft = draft_path(&app)?;
+    fs::write(&draft, "").map_err(|e| e.to_string())?;
+
+    // 5. Hide window
     if let Some(window) = app.get_webview_window("main") {
         window.hide().map_err(|e: tauri::Error| e.to_string())?;
     }
+
     Ok(())
 }
 
 #[tauri::command]
-pub async fn export_file(app: AppHandle, content: String, default_name: String) -> Result<(), String> {
+pub fn list_history(app: AppHandle) -> Result<Vec<HistoryEntry>, String> {
+    let history = history_dir(&app)?;
+    let index_path = history.join("index.json");
+    if !index_path.exists() {
+        return Ok(Vec::new());
+    }
+    let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&data).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_history_entry(app: AppHandle, id: String) -> Result<String, String> {
+    let history = history_dir(&app)?;
+    let file_path = history.join(format!("{}.md", id));
+    if !file_path.exists() {
+        return Err(format!("History entry not found: {}", id));
+    }
+    fs::read_to_string(&file_path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn export_file(
+    app: AppHandle,
+    content: String,
+    default_name: String,
+) -> Result<(), String> {
     let path = app
         .dialog()
         .file()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod commands;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::TrayIconBuilder,
-    Manager,
+    Emitter, Manager,
 };
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
@@ -49,15 +49,18 @@ pub fn run() {
                 app.set_menu(menu)?;
             }
 
-            // Tray icon menu: Show Editor + Quit
+            // Tray icon menu: Show Editor + History… + Quit
             let show_item =
                 MenuItem::with_id(app, "show-editor", "Show Editor", true, None::<&str>)?;
+            let history_item =
+                MenuItem::with_id(app, "open-history", "History\u{2026}", true, None::<&str>)?;
             let quit_item =
                 MenuItem::with_id(app, "quit-popmark", "Quit popmark", true, None::<&str>)?;
             let tray_menu = Menu::with_items(
                 app,
                 &[
                     &show_item,
+                    &history_item,
                     &PredefinedMenuItem::separator(app)?,
                     &quit_item,
                 ],
@@ -69,6 +72,13 @@ pub fn run() {
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.show();
                             let _ = window.set_focus();
+                        }
+                    }
+                    "open-history" => {
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                            let _ = window.emit("open-history-panel", ());
                         }
                     }
                     "quit-popmark" => {
@@ -103,6 +113,8 @@ pub fn run() {
             commands::save_draft,
             commands::copy_and_close,
             commands::export_file,
+            commands::list_history,
+            commands::get_history_entry,
         ])
         .on_window_event(|window, event| {
             // Intercept close request → hide instead of quitting

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useHistory } from "../hooks/useHistory";
+import type { HistoryEntry } from "../types/history";
+
+interface HistoryPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onLoadEntry: (id: string) => void;
+}
+
+function formatTimestamp(iso: string): string {
+  // iso: "2024-03-14T09:41:00" → "2024-03-14 09:41"
+  return iso.replace("T", " ").slice(0, 16);
+}
+
+function EntryItem({ entry, onLoad }: { entry: HistoryEntry; onLoad: (id: string) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onLoad(entry.id)}
+      className="w-full text-left px-3 py-2 rounded hover:bg-gray-100 active:bg-gray-200 cursor-default"
+    >
+      <div className="text-xs text-gray-400 mb-0.5">{formatTimestamp(entry.timestamp)}</div>
+      <div className="text-sm text-gray-700 truncate">{entry.title_preview}</div>
+    </button>
+  );
+}
+
+export function HistoryPanel({ isOpen, onClose, onLoadEntry }: HistoryPanelProps) {
+  const { entries, loading, loadHistory } = useHistory();
+
+  useEffect(() => {
+    if (isOpen) {
+      loadHistory();
+    }
+  }, [isOpen, loadHistory]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  return (
+    <div
+      className={[
+        "absolute inset-y-0 left-0 z-10 w-64 bg-white border-r border-gray-200 flex flex-col",
+        "transition-transform duration-200",
+        isOpen ? "translate-x-0" : "-translate-x-full",
+      ].join(" ")}
+    >
+      <div
+        className="flex items-center justify-between px-3 py-2 border-b border-gray-200 select-none"
+        data-tauri-drag-region
+      >
+        <span className="text-sm font-medium text-gray-600" data-tauri-drag-region>
+          History
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-600 cursor-default leading-none"
+          title="Close history panel"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-1">
+        {loading && <div className="px-3 py-4 text-sm text-gray-400 text-center">Loading…</div>}
+        {!loading && entries.length === 0 && (
+          <div className="px-3 py-4 text-sm text-gray-400 text-center">No history yet</div>
+        )}
+        {!loading &&
+          entries.map((entry) => <EntryItem key={entry.id} entry={entry} onLoad={onLoadEntry} />)}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,7 +2,12 @@ import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { invoke } from "@tauri-apps/api/core";
 
-export function Toolbar() {
+interface ToolbarProps {
+  isHistoryOpen: boolean;
+  onToggleHistory: () => void;
+}
+
+export function Toolbar({ isHistoryOpen, onToggleHistory }: ToolbarProps) {
   const [editor] = useLexicalComposerContext();
 
   function handleCopyAndClose() {
@@ -29,6 +34,19 @@ export function Toolbar() {
         popmark
       </span>
       <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onToggleHistory}
+          className={[
+            "px-3 py-1 text-sm rounded cursor-default",
+            isHistoryOpen
+              ? "bg-gray-200 text-gray-700 hover:bg-gray-300 active:bg-gray-400"
+              : "text-gray-600 hover:bg-gray-100 active:bg-gray-200",
+          ].join(" ")}
+          title="Toggle history panel"
+        >
+          History
+        </button>
         <button
           type="button"
           onClick={handleExport}

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -18,9 +18,12 @@ import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import type { EditorState } from "lexical";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { HistoryPanel } from "../components/HistoryPanel";
 import { Toolbar } from "../components/Toolbar";
+import { useHistory } from "../hooks/useHistory";
 
 const initialConfig = {
   namespace: "popmark",
@@ -48,8 +51,18 @@ function loadDraft(editor: ReturnType<typeof useLexicalComposerContext>[0]) {
   });
 }
 
-// Loads draft from backend on mount/focus and sets up ⌘Return keybind
-function EditorPlugins() {
+interface EditorPluginsProps {
+  setIsHistoryOpen: (open: boolean) => void;
+  pendingContent: string | null;
+  onPendingConsumed: () => void;
+}
+
+// Handles draft load/save, keyboard shortcuts, and history entry loading
+function EditorPlugins({
+  setIsHistoryOpen,
+  pendingContent,
+  onPendingConsumed,
+}: EditorPluginsProps) {
   const [editor] = useLexicalComposerContext();
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -79,6 +92,37 @@ function EditorPlugins() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [editor]);
 
+  // Listen for "open-history-panel" event emitted by the tray menu
+  useEffect(() => {
+    const unlisten = listen("open-history-panel", () => {
+      setIsHistoryOpen(true);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [setIsHistoryOpen]);
+
+  // Load a pending history entry into the editor
+  useEffect(() => {
+    if (pendingContent === null) return;
+
+    let hasContent = false;
+    editor.getEditorState().read(() => {
+      const text = $convertToMarkdownString(TRANSFORMERS);
+      hasContent = text.trim().length > 0;
+    });
+
+    if (hasContent && !window.confirm("Replace current draft with this history entry?")) {
+      onPendingConsumed();
+      return;
+    }
+
+    editor.update(() => {
+      $convertFromMarkdownString(pendingContent, TRANSFORMERS);
+    });
+    onPendingConsumed();
+  }, [editor, pendingContent, onPendingConsumed]);
+
   function handleChange(editorState: EditorState) {
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
     debounceTimer.current = setTimeout(() => {
@@ -93,10 +137,27 @@ function EditorPlugins() {
 }
 
 export function MarkdownEditor() {
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [pendingContent, setPendingContent] = useState<string | null>(null);
+  const { getEntry } = useHistory();
+
+  const handleLoadEntry = useCallback(
+    async (id: string) => {
+      const content = await getEntry(id);
+      setPendingContent(content);
+      setIsHistoryOpen(false);
+    },
+    [getEntry],
+  );
+
+  const handlePendingConsumed = useCallback(() => {
+    setPendingContent(null);
+  }, []);
+
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <Toolbar />
-      <div className="relative h-full">
+      <Toolbar isHistoryOpen={isHistoryOpen} onToggleHistory={() => setIsHistoryOpen((v) => !v)} />
+      <div className="relative flex-1 overflow-hidden">
         <RichTextPlugin
           contentEditable={<ContentEditable className="h-full p-4 outline-none" />}
           placeholder={
@@ -109,7 +170,16 @@ export function MarkdownEditor() {
         <HistoryPlugin />
         <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
         <HorizontalRulePlugin />
-        <EditorPlugins />
+        <EditorPlugins
+          setIsHistoryOpen={setIsHistoryOpen}
+          pendingContent={pendingContent}
+          onPendingConsumed={handlePendingConsumed}
+        />
+        <HistoryPanel
+          isOpen={isHistoryOpen}
+          onClose={() => setIsHistoryOpen(false)}
+          onLoadEntry={handleLoadEntry}
+        />
       </div>
     </LexicalComposer>
   );

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,0 +1,24 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useState } from "react";
+import type { HistoryEntry } from "../types/history";
+
+export function useHistory() {
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadHistory = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await invoke<HistoryEntry[]>("list_history");
+      setEntries(result);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const getEntry = useCallback(async (id: string): Promise<string> => {
+    return invoke<string>("get_history_entry", { id });
+  }, []);
+
+  return { entries, loading, loadHistory, getEntry };
+}

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,0 +1,5 @@
+export interface HistoryEntry {
+  id: string;
+  timestamp: string;
+  title_preview: string;
+}


### PR DESCRIPTION
Closes #5

## Summary

- **Rust**: Extended `copy_and_close` to save `history/<ISO8601>.md`, prepend entry to `index.json`, and clear `draft.md`; added `list_history` and `get_history_entry` IPC commands; added `HistoryEntry` struct (serde); added "History…" tray menu item that emits `open-history-panel` event
- **React**: Added `HistoryEntry` interface, `useHistory` hook, `HistoryPanel` component (slides in from left with Tailwind `translate-x` transition), History toolbar toggle button, `open-history-panel` event listener, confirmation dialog when loading into a non-empty draft, Escape key to close panel

## Test plan

- [ ] Copy & Close saves a `.md` file under `~/Library/Application Support/popmark/history/` and updates `index.json`
- [ ] After Copy & Close, draft is cleared and editor opens blank on next launch
- [ ] History toolbar button opens/closes the panel
- [ ] Panel lists entries in reverse-chronological order with timestamp and title preview
- [ ] Clicking an entry with an empty draft loads it immediately
- [ ] Clicking an entry with a non-empty draft shows a confirmation dialog before replacing
- [ ] Pressing Escape closes the history panel
- [ ] Tray menu "History…" shows the editor window with the history panel open