### PR TITLE
feat: implement Stage 4 settings & polish

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,11 +614,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -618,7 +649,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -736,7 +767,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2547,6 +2578,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
@@ -2805,6 +2837,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3535,7 +3578,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3585,7 +3628,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -3655,6 +3698,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4136,7 +4193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5098,6 +5155,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5228,7 +5294,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,4 +19,5 @@ tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
+tauri-plugin-autostart = "2"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,9 +2,42 @@ use chrono::Local;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use tauri::{AppHandle, Manager};
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_dialog::{DialogExt, FilePath};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
+
+// ---------------------------------------------------------------------------
+// App state: tracks the currently registered global shortcut
+// ---------------------------------------------------------------------------
+
+pub struct AppState {
+    pub current_shortcut: Mutex<Option<Shortcut>>,
+}
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Settings {
+    pub hotkey: String,
+    pub launch_at_login: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            hotkey: "alt+m".to_string(),
+            launch_at_login: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// History entry
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HistoryEntry {
@@ -12,6 +45,10 @@ pub struct HistoryEntry {
     pub timestamp: String,
     pub title_preview: String,
 }
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
 
 fn app_data_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
@@ -32,6 +69,10 @@ fn history_dir(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
+fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app_data_dir(app)?.join("settings.json"))
+}
+
 fn extract_title_preview(content: &str) -> String {
     let first_line = content
         .lines()
@@ -48,6 +89,83 @@ fn extract_title_preview(content: &str) -> String {
         stripped.to_string()
     }
 }
+
+// ---------------------------------------------------------------------------
+// Shortcut registration helper
+// ---------------------------------------------------------------------------
+
+/// Unregister the previous global shortcut (if any) and register a new one
+/// that toggles window visibility. Persists the active shortcut in AppState.
+pub fn re_register_shortcut(app: &AppHandle, hotkey: &str) -> Result<(), String> {
+    let shortcut: Shortcut = hotkey
+        .parse()
+        .map_err(|e| format!("Invalid hotkey '{hotkey}': {e}"))?;
+
+    let state = app.state::<AppState>();
+    let mut current = state.current_shortcut.lock().unwrap();
+    if let Some(old) = current.take() {
+        let _ = app.global_shortcut().unregister(old);
+    }
+
+    app.global_shortcut()
+        .on_shortcut(shortcut.clone(), move |app, _shortcut, event| {
+            if event.state == ShortcutState::Pressed {
+                if let Some(window) = app.get_webview_window("main") {
+                    if window.is_visible().unwrap_or(false) {
+                        let _ = window.hide();
+                    } else {
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                        let _ = window.emit("window-shown", ());
+                    }
+                }
+            }
+        })
+        .map_err(|e| e.to_string())?;
+
+    *current = Some(shortcut);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// IPC commands: settings
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn get_settings(app: AppHandle) -> Result<Settings, String> {
+    let path = settings_path(&app)?;
+    if path.exists() {
+        let data = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&data).map_err(|e| e.to_string())
+    } else {
+        Ok(Settings::default())
+    }
+}
+
+#[tauri::command]
+pub fn save_settings(app: AppHandle, settings: Settings) -> Result<(), String> {
+    // Persist to disk
+    let path = settings_path(&app)?;
+    let json = serde_json::to_string_pretty(&settings).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    // Re-register global shortcut with new hotkey
+    re_register_shortcut(&app, &settings.hotkey)?;
+
+    // Toggle launch-at-login
+    use tauri_plugin_autostart::ManagerExt;
+    if settings.launch_at_login {
+        app.autolaunch().enable().map_err(|e| e.to_string())?;
+    } else {
+        app.autolaunch().disable().map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// IPC commands: draft
+// ---------------------------------------------------------------------------
 
 #[tauri::command]
 pub fn get_draft(app: AppHandle) -> Result<String, String> {
@@ -113,6 +231,10 @@ pub fn copy_and_close(app: AppHandle, content: String) -> Result<(), String> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// IPC commands: history
+// ---------------------------------------------------------------------------
+
 #[tauri::command]
 pub fn list_history(app: AppHandle) -> Result<Vec<HistoryEntry>, String> {
     let history = history_dir(&app)?;
@@ -133,6 +255,10 @@ pub fn get_history_entry(app: AppHandle, id: String) -> Result<String, String> {
     }
     fs::read_to_string(&file_path).map_err(|e| e.to_string())
 }
+
+// ---------------------------------------------------------------------------
+// IPC commands: export
+// ---------------------------------------------------------------------------
 
 #[tauri::command]
 pub async fn export_file(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 mod commands;
 
+use commands::AppState;
+use std::sync::Mutex;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::TrayIconBuilder,
     Emitter, Manager,
 };
-use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
+use tauri_plugin_autostart::MacosLauncher;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -13,6 +15,13 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(tauri_plugin_autostart::init(
+            MacosLauncher::LaunchAgent,
+            None,
+        ))
+        .manage(AppState {
+            current_shortcut: Mutex::new(None),
+        })
         .setup(|app| {
             // macOS system menu bar: App menu + Edit menu
             #[cfg(target_os = "macos")]
@@ -49,11 +58,13 @@ pub fn run() {
                 app.set_menu(menu)?;
             }
 
-            // Tray icon menu: Show Editor + History… + Quit
+            // Tray icon menu: Show Editor + History… + Settings… + Quit
             let show_item =
                 MenuItem::with_id(app, "show-editor", "Show Editor", true, None::<&str>)?;
             let history_item =
                 MenuItem::with_id(app, "open-history", "History\u{2026}", true, None::<&str>)?;
+            let settings_item =
+                MenuItem::with_id(app, "open-settings", "Settings\u{2026}", true, None::<&str>)?;
             let quit_item =
                 MenuItem::with_id(app, "quit-popmark", "Quit popmark", true, None::<&str>)?;
             let tray_menu = Menu::with_items(
@@ -61,6 +72,7 @@ pub fn run() {
                 &[
                     &show_item,
                     &history_item,
+                    &settings_item,
                     &PredefinedMenuItem::separator(app)?,
                     &quit_item,
                 ],
@@ -72,13 +84,23 @@ pub fn run() {
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.show();
                             let _ = window.set_focus();
+                            let _ = window.emit("window-shown", ());
                         }
                     }
                     "open-history" => {
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.show();
                             let _ = window.set_focus();
+                            let _ = window.emit("window-shown", ());
                             let _ = window.emit("open-history-panel", ());
+                        }
+                    }
+                    "open-settings" => {
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                            let _ = window.emit("window-shown", ());
+                            let _ = window.emit("open-settings-panel", ());
                         }
                     }
                     "quit-popmark" => {
@@ -91,20 +113,11 @@ pub fn run() {
             }
             builder.build(app)?;
 
-            // Register ⌥M global shortcut to show/hide the window
-            let shortcut = Shortcut::new(Some(Modifiers::ALT), Code::KeyM);
-            app.global_shortcut().on_shortcut(shortcut, move |app, _shortcut, event| {
-                if event.state == ShortcutState::Pressed {
-                    if let Some(window) = app.get_webview_window("main") {
-                        if window.is_visible().unwrap_or(false) {
-                            let _ = window.hide();
-                        } else {
-                            let _ = window.show();
-                            let _ = window.set_focus();
-                        }
-                    }
-                }
-            })?;
+            // Read saved hotkey from settings and register global shortcut
+            let hotkey = commands::get_settings(app.handle().clone())
+                .unwrap_or_default()
+                .hotkey;
+            commands::re_register_shortcut(app.handle(), &hotkey)?;
 
             Ok(())
         })
@@ -115,6 +128,8 @@ pub fn run() {
             commands::export_file,
             commands::list_history,
             commands::get_history_entry,
+            commands::get_settings,
+            commands::save_settings,
         ])
         .on_window_event(|window, event| {
             // Intercept close request → hide instead of quitting

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { MarkdownEditor } from "./editor/MarkdownEditor";
 
 function App() {
   return (
-    <div className="h-screen w-screen flex flex-col">
+    <div className="h-screen w-screen flex flex-col bg-white dark:bg-gray-900">
       <MarkdownEditor />
     </div>
   );

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -18,10 +18,12 @@ function EntryItem({ entry, onLoad }: { entry: HistoryEntry; onLoad: (id: string
     <button
       type="button"
       onClick={() => onLoad(entry.id)}
-      className="w-full text-left px-3 py-2 rounded hover:bg-gray-100 active:bg-gray-200 cursor-default"
+      className="w-full text-left px-3 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700 cursor-default"
     >
-      <div className="text-xs text-gray-400 mb-0.5">{formatTimestamp(entry.timestamp)}</div>
-      <div className="text-sm text-gray-700 truncate">{entry.title_preview}</div>
+      <div className="text-xs text-gray-400 dark:text-gray-500 mb-0.5">
+        {formatTimestamp(entry.timestamp)}
+      </div>
+      <div className="text-sm text-gray-700 dark:text-gray-300 truncate">{entry.title_preview}</div>
     </button>
   );
 }
@@ -49,22 +51,25 @@ export function HistoryPanel({ isOpen, onClose, onLoadEntry }: HistoryPanelProps
   return (
     <div
       className={[
-        "absolute inset-y-0 left-0 z-10 w-64 bg-white border-r border-gray-200 flex flex-col",
+        "absolute inset-y-0 left-0 z-10 w-64 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 flex flex-col",
         "transition-transform duration-200",
         isOpen ? "translate-x-0" : "-translate-x-full",
       ].join(" ")}
     >
       <div
-        className="flex items-center justify-between px-3 py-2 border-b border-gray-200 select-none"
+        className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700 select-none"
         data-tauri-drag-region
       >
-        <span className="text-sm font-medium text-gray-600" data-tauri-drag-region>
+        <span
+          className="text-sm font-medium text-gray-600 dark:text-gray-400"
+          data-tauri-drag-region
+        >
           History
         </span>
         <button
           type="button"
           onClick={onClose}
-          className="text-gray-400 hover:text-gray-600 cursor-default leading-none"
+          className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-default leading-none"
           title="Close history panel"
         >
           ✕
@@ -72,9 +77,16 @@ export function HistoryPanel({ isOpen, onClose, onLoadEntry }: HistoryPanelProps
       </div>
 
       <div className="flex-1 overflow-y-auto p-1">
-        {loading && <div className="px-3 py-4 text-sm text-gray-400 text-center">Loading…</div>}
+        {loading && (
+          <div className="px-3 py-4 text-sm text-gray-400 dark:text-gray-500 text-center">
+            Loading…
+          </div>
+        )}
         {!loading && entries.length === 0 && (
-          <div className="px-3 py-4 text-sm text-gray-400 text-center">No history yet</div>
+          <div className="px-3 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+            <div className="mb-1">No history yet</div>
+            <div className="text-xs">Use Copy &amp; Close to save entries here</div>
+          </div>
         )}
         {!loading &&
           entries.map((entry) => <EntryItem key={entry.id} entry={entry} onLoad={onLoadEntry} />)}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,0 +1,198 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useRef, useState } from "react";
+
+interface Settings {
+  hotkey: string;
+  launch_at_login: boolean;
+}
+
+interface SettingsPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// Map a keyboard Code (e.g. "KeyM", "Space") to the hotkey segment (e.g. "m", "space")
+function codeToHotkeySegment(code: string): string {
+  if (code.startsWith("Key")) return code.slice(3).toLowerCase();
+  if (code.startsWith("Digit")) return code.slice(5);
+  return code.toLowerCase();
+}
+
+// Format a stored hotkey string (e.g. "alt+m") as macOS symbols (e.g. "⌥M")
+function formatHotkey(hotkey: string): string {
+  return hotkey
+    .split("+")
+    .map((part) => {
+      switch (part.toLowerCase()) {
+        case "ctrl":
+        case "control":
+          return "⌃";
+        case "alt":
+          return "⌥";
+        case "shift":
+          return "⇧";
+        case "meta":
+        case "super":
+        case "cmd":
+        case "command":
+          return "⌘";
+        case "space":
+          return "Space";
+        default:
+          return part.toUpperCase();
+      }
+    })
+    .join("");
+}
+
+export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
+  const [savedHotkey, setSavedHotkey] = useState("alt+m");
+  const [capturedHotkey, setCapturedHotkey] = useState("alt+m");
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [launchAtLogin, setLaunchAtLogin] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Load current settings when panel opens
+  useEffect(() => {
+    if (!isOpen) return;
+    invoke<Settings>("get_settings").then((s) => {
+      setSavedHotkey(s.hotkey);
+      setCapturedHotkey(s.hotkey);
+      setLaunchAtLogin(s.launch_at_login);
+    });
+    // Focus the dialog so ESC works immediately
+    dialogRef.current?.focus();
+  }, [isOpen]);
+
+  // ESC to close (when not capturing)
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && !isCapturing) {
+        handleCancel();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  });
+
+  function startCapture() {
+    setIsCapturing(true);
+    dialogRef.current?.querySelector<HTMLElement>("[data-capture-box]")?.focus();
+  }
+
+  function handleCaptureKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.key === "Escape") {
+      setIsCapturing(false);
+      setCapturedHotkey(savedHotkey);
+      return;
+    }
+
+    // Ignore modifier-only presses
+    if (["Alt", "Control", "Shift", "Meta", "Super"].includes(e.key)) return;
+
+    const parts: string[] = [];
+    if (e.ctrlKey) parts.push("ctrl");
+    if (e.altKey) parts.push("alt");
+    if (e.shiftKey) parts.push("shift");
+    if (e.metaKey) parts.push("super");
+    parts.push(codeToHotkeySegment(e.code));
+
+    setCapturedHotkey(parts.join("+"));
+    setIsCapturing(false);
+  }
+
+  async function handleSave() {
+    await invoke("save_settings", {
+      settings: { hotkey: capturedHotkey, launch_at_login: launchAtLogin },
+    });
+    setSavedHotkey(capturedHotkey);
+    onClose();
+  }
+
+  function handleCancel() {
+    setIsCapturing(false);
+    setCapturedHotkey(savedHotkey);
+    onClose();
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    // Backdrop
+    <div className="fixed inset-0 bg-black/50 z-20 flex items-center justify-center">
+      {/* Dialog box */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+        tabIndex={-1}
+        className="w-80 bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 outline-none"
+      >
+        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-4">Settings</h2>
+
+        {/* Global shortcut */}
+        <div className="mb-4">
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+            Global Shortcut
+          </p>
+          {/* Hotkey capture box: a <button> that turns into a capture target when clicked */}
+          <button
+            type="button"
+            data-capture-box
+            className={[
+              "w-full px-3 py-2 border rounded text-center font-mono text-sm select-none cursor-pointer",
+              isCapturing
+                ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+                : "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:border-gray-400 dark:hover:border-gray-500",
+            ].join(" ")}
+            onClick={isCapturing ? undefined : startCapture}
+            onKeyDown={isCapturing ? handleCaptureKeyDown : undefined}
+            aria-label={
+              isCapturing
+                ? "Press the desired key combination"
+                : `Current shortcut: ${capturedHotkey}`
+            }
+          >
+            {isCapturing ? "Press shortcut…" : formatHotkey(capturedHotkey)}
+          </button>
+        </div>
+
+        {/* Launch at login */}
+        <div className="mb-6">
+          <label className="flex items-center gap-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={launchAtLogin}
+              onChange={(e) => setLaunchAtLogin(e.target.checked)}
+              className="w-4 h-4 accent-blue-500"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">Launch at login</span>
+          </label>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="px-4 py-1.5 text-sm text-gray-700 dark:text-gray-300 rounded hover:bg-gray-100 dark:hover:bg-gray-700 active:bg-gray-200 dark:active:bg-gray-600 cursor-default"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="px-4 py-1.5 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 active:bg-blue-700 cursor-default"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -5,9 +5,10 @@ import { invoke } from "@tauri-apps/api/core";
 interface ToolbarProps {
   isHistoryOpen: boolean;
   onToggleHistory: () => void;
+  onOpenSettings: () => void;
 }
 
-export function Toolbar({ isHistoryOpen, onToggleHistory }: ToolbarProps) {
+export function Toolbar({ isHistoryOpen, onToggleHistory, onOpenSettings }: ToolbarProps) {
   const [editor] = useLexicalComposerContext();
 
   function handleCopyAndClose() {
@@ -27,10 +28,10 @@ export function Toolbar({ isHistoryOpen, onToggleHistory }: ToolbarProps) {
   return (
     // data-tauri-drag-region makes the toolbar area draggable (no native title bar)
     <div
-      className="flex items-center justify-between px-3 py-2 border-b border-gray-200 select-none"
+      className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700 select-none bg-white dark:bg-gray-900"
       data-tauri-drag-region
     >
-      <span className="text-sm font-medium text-gray-600" data-tauri-drag-region>
+      <span className="text-sm font-medium text-gray-600 dark:text-gray-400" data-tauri-drag-region>
         popmark
       </span>
       <div className="flex items-center gap-2">
@@ -40,8 +41,8 @@ export function Toolbar({ isHistoryOpen, onToggleHistory }: ToolbarProps) {
           className={[
             "px-3 py-1 text-sm rounded cursor-default",
             isHistoryOpen
-              ? "bg-gray-200 text-gray-700 hover:bg-gray-300 active:bg-gray-400"
-              : "text-gray-600 hover:bg-gray-100 active:bg-gray-200",
+              ? "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500"
+              : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700",
           ].join(" ")}
           title="Toggle history panel"
         >
@@ -50,10 +51,18 @@ export function Toolbar({ isHistoryOpen, onToggleHistory }: ToolbarProps) {
         <button
           type="button"
           onClick={handleExport}
-          className="px-3 py-1 text-sm text-gray-600 rounded hover:bg-gray-100 active:bg-gray-200 cursor-default"
+          className="px-3 py-1 text-sm text-gray-600 dark:text-gray-400 rounded hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700 cursor-default"
           title="Export as Markdown file"
         >
           Export…
+        </button>
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="px-3 py-1 text-sm text-gray-600 dark:text-gray-400 rounded hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700 cursor-default"
+          title="Settings"
+        >
+          Settings
         </button>
         <button
           type="button"

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -22,6 +22,7 @@ import { listen } from "@tauri-apps/api/event";
 import type { EditorState } from "lexical";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HistoryPanel } from "../components/HistoryPanel";
+import { SettingsPanel } from "../components/SettingsPanel";
 import { Toolbar } from "../components/Toolbar";
 import { useHistory } from "../hooks/useHistory";
 
@@ -53,13 +54,15 @@ function loadDraft(editor: ReturnType<typeof useLexicalComposerContext>[0]) {
 
 interface EditorPluginsProps {
   setIsHistoryOpen: (open: boolean) => void;
+  setIsSettingsOpen: (open: boolean) => void;
   pendingContent: string | null;
   onPendingConsumed: () => void;
 }
 
-// Handles draft load/save, keyboard shortcuts, and history entry loading
+// Handles draft load/save, keyboard shortcuts, and panel event listening
 function EditorPlugins({
   setIsHistoryOpen,
+  setIsSettingsOpen,
   pendingContent,
   onPendingConsumed,
 }: EditorPluginsProps) {
@@ -68,6 +71,16 @@ function EditorPlugins({
 
   useEffect(() => {
     loadDraft(editor);
+  }, [editor]);
+
+  // Auto-focus editor when the window is shown via global shortcut or tray
+  useEffect(() => {
+    const unlisten = listen("window-shown", () => {
+      editor.focus();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
   }, [editor]);
 
   useEffect(() => {
@@ -101,6 +114,16 @@ function EditorPlugins({
       unlisten.then((fn) => fn());
     };
   }, [setIsHistoryOpen]);
+
+  // Listen for "open-settings-panel" event emitted by the tray menu
+  useEffect(() => {
+    const unlisten = listen("open-settings-panel", () => {
+      setIsSettingsOpen(true);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [setIsSettingsOpen]);
 
   // Load a pending history entry into the editor
   useEffect(() => {
@@ -138,6 +161,7 @@ function EditorPlugins({
 
 export function MarkdownEditor() {
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [pendingContent, setPendingContent] = useState<string | null>(null);
   const { getEntry } = useHistory();
 
@@ -156,13 +180,19 @@ export function MarkdownEditor() {
 
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <Toolbar isHistoryOpen={isHistoryOpen} onToggleHistory={() => setIsHistoryOpen((v) => !v)} />
-      <div className="relative flex-1 overflow-hidden">
+      <Toolbar
+        isHistoryOpen={isHistoryOpen}
+        onToggleHistory={() => setIsHistoryOpen((v) => !v)}
+        onOpenSettings={() => setIsSettingsOpen(true)}
+      />
+      <div className="relative flex-1 overflow-hidden bg-white dark:bg-gray-900">
         <RichTextPlugin
-          contentEditable={<ContentEditable className="h-full p-4 outline-none" />}
+          contentEditable={
+            <ContentEditable className="h-full p-4 outline-none text-gray-900 dark:text-gray-100" />
+          }
           placeholder={
-            <div className="absolute top-4 left-4 text-gray-400 pointer-events-none">
-              Start writing...
+            <div className="absolute top-4 left-4 text-gray-400 dark:text-gray-600 pointer-events-none">
+              Start writing…
             </div>
           }
           ErrorBoundary={LexicalErrorBoundary}
@@ -172,6 +202,7 @@ export function MarkdownEditor() {
         <HorizontalRulePlugin />
         <EditorPlugins
           setIsHistoryOpen={setIsHistoryOpen}
+          setIsSettingsOpen={setIsSettingsOpen}
           pendingContent={pendingContent}
           onPendingConsumed={handlePendingConsumed}
         />
@@ -180,6 +211,7 @@ export function MarkdownEditor() {
           onClose={() => setIsHistoryOpen(false)}
           onLoadEntry={handleLoadEntry}
         />
+        <SettingsPanel isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
       </div>
     </LexicalComposer>
   );


### PR DESCRIPTION
Closes #6

## Summary

- **Settings IPC**: `get_settings` / `save_settings` Tauri commands read/write `settings.json` with fallback defaults (`hotkey: "alt+m"`, `launch_at_login: false`)
- **Dynamic hotkey re-registration**: `re_register_shortcut()` helper in `commands.rs` unregisters the old shortcut and registers the new one on every `save_settings` call; also used at startup to apply the saved hotkey
- **AppState**: `Mutex<Option<Shortcut>>` managed state tracks the active shortcut so only that shortcut is unregistered (not all shortcuts)
- **tauri-plugin-autostart**: enable/disable launch-at-login via `LaunchAgent` on macOS
- **`window-shown` event**: emitted after `window.show()` + `window.set_focus()` in both the global shortcut handler and all tray "Show" actions; React listens and auto-focuses the editor
- **SettingsPanel**: modal overlay (fixed backdrop + centered `w-80` card) with hotkey capture input (`<button>` that captures the next keydown) displaying macOS-style symbols (⌥M, ⌃⇧Space…), launch-at-login checkbox, Save / Cancel, ESC to close
- **Tray "Settings…" item**: emits `open-settings-panel` to open the modal from the menu bar
- **Dark mode**: `dark:` Tailwind variants added to all components (Toolbar, HistoryPanel, MarkdownEditor, SettingsPanel, App) — follows `prefers-color-scheme: dark` automatically via Tailwind v4
- **Empty history UX**: expanded empty-state message with a hint to use "Copy & Close"

## Test plan

- [ ] Change hotkey in Settings → new key combination shows/hides the window
- [ ] Enable "Launch at login" → app appears in macOS Login Items (verify in production build)
- [ ] Dark mode follows macOS system appearance setting
- [ ] ESC closes Settings panel without saving
- [ ] Tray "Settings…" opens the modal
- [ ] Window auto-focuses the editor when shown via shortcut or tray