### PR TITLE
docs: update requirements and spec with new feature requirements

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -21,8 +21,10 @@ popmark is a macOS application with a tray icon and standard menu bar, providing
   - Markdown syntax markers (`#`, `**`, `` ` ``, etc.) remain visible.
   - Visual styling (font size, weight, color, etc.) is applied at the same time.
   - Users can edit the raw markers directly; styling updates live.
-- Supported Markdown elements: headings H1–H6, bold, italic, bold+italic, strikethrough, inline code, fenced code blocks (with optional language tag), blockquotes, unordered and ordered lists, horizontal rules, and links.
+- Supported Markdown elements: headings H1–H6, bold, italic, bold+italic, strikethrough, inline code, fenced code blocks (with optional language tag), blockquotes, unordered and ordered lists, checkbox (task) lists, horizontal rules, and links.
+- Checkbox lists use `- [ ]` (unchecked) and `- [x]` (checked) syntax.
 - Standard Markdown syntax is used (`#` for H1, `##` for H2, etc.).
+- Pressing Enter on a blank list item exits list mode and returns to normal paragraph mode.
 
 ---
 
@@ -47,6 +49,14 @@ The next time the editor is opened it shows a blank document.
 
 ---
 
+## 5a. New Document
+
+- Users can create a new document (clear the editor) at any time via the toolbar or system menu bar (⌘N).
+- If the current draft is non-empty, it is **automatically saved to history** before clearing (no confirmation required).
+- After clearing, the editor opens a blank document.
+
+---
+
 ## 6. History
 
 - Every document saved via Copy & Close is retained in history (documents are never automatically deleted).
@@ -67,10 +77,11 @@ The next time the editor is opened it shows a blank document.
 
 ## 8. App Lifecycle & Menu Bar
 
-- The app runs as a standard macOS application: a Dock icon is visible, and the standard macOS menu bar (including an Edit menu) is available when the editor window is focused. A tray icon also appears in the macOS status bar for quick access.
+- The app runs as a standard macOS application: a Dock icon is visible, and the standard macOS menu bar is available when the editor window is focused. The menu bar provides a File menu (New Document, Export, Copy & Close), an Edit menu, and access to History and Settings from the app menu. A tray icon also appears in the macOS status bar for quick access.
 - The app starts at login (user-configurable).
 - The app **never quits** unless the user explicitly selects "Quit" from the tray menu or presses Cmd+Q. Closing the editor window hides it; it does not terminate the process.
 - The editor window is hidden by default and appears only when triggered by the global hotkey or via the tray menu.
+- Pressing Esc hides the editor window.
 
 ---
 
@@ -97,6 +108,15 @@ The following are explicitly **not** required:
 
 ---
 
+## 10a. Future / Nice-to-Have
+
+The following are deferred to a future version:
+
+- Drag-and-drop reordering of list items in the editor
+- Shift+Arrow keys to move selected nodes (list items, paragraphs) up or down
+
+---
+
 ## 11. Technical Constraints
 
 These technology choices are fixed:
@@ -104,5 +124,5 @@ These technology choices are fixed:
 | Layer | Technology |
 |-------|-----------|
 | Native shell | Tauri 2.x (Rust) |
-| Frontend | React 18 + Vite |
+| Frontend | React 19 + Vite |
 | Rich text engine | Lexical |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -18,7 +18,7 @@ popmark is not a file manager or a notes app. It is a fast scratch pad optimized
 | Layer    | Technology      | Responsibility                                         |
 |----------|-----------------|--------------------------------------------------------|
 | Shell    | Tauri 2.x (Rust)| Menu bar agent, global hotkey, clipboard, file I/O     |
-| UI       | React 18 + Vite | Editor window, toolbar, history panel                  |
+| UI       | React 19 + Vite | Editor window, toolbar, history panel                  |
 | Editor   | Lexical         | WYSIWYG Markdown rendering                             |
 | Styling  | Tailwind CSS    | UI layout and theming (dark mode support)              |
 
@@ -49,8 +49,9 @@ popmark is not a file manager or a notes app. It is a fast scratch pad optimized
 
 - **Position:** Centered on the active screen at open time.
 - **Default size:** 700 × 500 px (resizable).
-- **Window style:** Minimal chrome (no standard title bar); custom toolbar at the top.
+- **Window style:** Standard macOS window with native title bar. The window can be moved by dragging the title bar in the standard macOS manner. A custom toolbar with action buttons appears below the title bar.
 - **Always on top:** The window appears above other windows but does not forcibly stay on top after losing focus (standard window behavior).
+- **Keyboard shortcut:** `Esc` hides the editor window (regardless of whether a panel is open).
 
 ---
 
@@ -78,10 +79,13 @@ The editor uses **source-visible WYSIWYG** (Obsidian style):
 | Blockquote          | `>`                           |
 | Unordered list      | `-` or `*`                    |
 | Ordered list        | `1.`                          |
+| Checkbox list       | `- [ ] task` / `- [x] done`  |
 | Horizontal rule     | `---`                         |
 | Link                | `[label](url)`                |
 
 Inter-document links (wiki-links, `[[…]]`) are **not supported**.
+
+**List exit behavior:** Pressing Enter on a blank list item exits the list and inserts a regular paragraph.
 
 ### 6.3 Toolbar
 
@@ -89,6 +93,7 @@ A minimal toolbar appears at the top of the editor window:
 
 | Button / Control | Action                        |
 |------------------|-------------------------------|
+| New              | Auto-save draft to history (if non-empty), clear draft, start new document |
 | Copy & Close     | Copy Markdown, save to history, clear draft, hide window |
 | History          | Open/close the history panel  |
 | Export…          | Save current content as `.md` via save dialog |
@@ -189,23 +194,36 @@ The standard macOS menu bar is active when the editor window is focused. It prov
 
 **popmark menu**
 
-| Item         | Action                        |
-|--------------|-------------------------------|
-| About popmark | Show the About dialog        |
-| —            | Separator                     |
-| Quit popmark | Terminate the app (Cmd+Q)    |
+| Item          | Shortcut | Action                        |
+|---------------|----------|-------------------------------|
+| About popmark |          | Show the About dialog         |
+| —             |          | Separator                     |
+| History…      | ⌘H       | Show editor with history panel open |
+| Settings…     | ⌘,       | Open settings panel           |
+| —             |          | Separator                     |
+| Quit popmark  | ⌘Q       | Terminate the app             |
+
+**File menu**
+
+| Item          | Shortcut | Action                        |
+|---------------|----------|-------------------------------|
+| New Document  | ⌘N       | Auto-save draft to history (if non-empty), clear draft, start new |
+| —             |          | Separator                     |
+| Export…       | ⌘S       | Save current content as `.md` via save dialog |
+| —             |          | Separator                     |
+| Copy & Close  | ⌘Return  | Copy to clipboard, save to history, clear draft, hide window |
 
 **Edit menu**
 
-| Item         | Shortcut | Action           |
-|--------------|----------|------------------|
-| Undo         | Cmd+Z    | Undo last edit   |
-| Redo         | Cmd+Shift+Z | Redo last edit |
-| —            |          | Separator        |
-| Cut          | Cmd+X    | Cut selection    |
-| Copy         | Cmd+C    | Copy selection   |
-| Paste        | Cmd+V    | Paste            |
-| Select All   | Cmd+A    | Select all text  |
+| Item         | Shortcut    | Action           |
+|--------------|-------------|------------------|
+| Undo         | ⌘Z          | Undo last edit   |
+| Redo         | ⌘⇧Z         | Redo last edit   |
+| —            |             | Separator        |
+| Cut          | ⌘X          | Cut selection    |
+| Copy         | ⌘C          | Copy selection   |
+| Paste        | ⌘V          | Paste            |
+| Select All   | ⌘A          | Select all text  |
 
 ---
 
@@ -251,6 +269,7 @@ All files are managed by the Tauri backend (Rust). The frontend never accesses t
 | `export_file`            | React → Rust    | Open save dialog and write file              |
 | `get_settings`           | Rust → React    | Return current settings                      |
 | `save_settings`          | React → Rust    | Persist settings changes                     |
+| `new_document`           | React → Rust    | Auto-save current draft to history (if non-empty), then clear draft |
 
 ### Lexical Markdown Serialization
 
@@ -275,3 +294,8 @@ The following features are explicitly **not** included in this version:
 - Tags or categories for history entries
 - Sync / cloud backup
 - Windows or Linux support
+
+The following are deferred to a future version:
+
+- Drag-and-drop reordering of list items in the editor
+- Shift+Arrow keys to move selected nodes (list items, paragraphs) up or down


### PR DESCRIPTION
## Summary

- Add checkbox/task list support and list exit behavior to editor spec
- Add New Document feature (auto-saves existing draft to history before clearing)
- Expand system menu bar with File menu (New Document, Export, Copy & Close) and History/Settings in app menu
- Switch window style to standard macOS native title bar (was custom titlebar-less)
- Add Esc key behavior: always hides the editor window
- Add `new_document` IPC command to the Tauri command table
- Add Future/Nice-to-Have section for drag-and-drop and Shift+Arrow reordering
- Fix React version: 18 → 19 (matches actual package.json)

## Test plan

- [ ] Review REQUIREMENTS.md for completeness and consistency
- [ ] Review SPEC.md for consistency with REQUIREMENTS.md
- [ ] Verify all items from `docs/REQUIREMENTS.ja.md` are addressed