### PR TITLE
feat: implement Stage 8 — system menu bar

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,16 +4,18 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager};
+use tauri::menu::CheckMenuItem;
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_dialog::{DialogExt, FilePath};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
 // ---------------------------------------------------------------------------
-// App state: tracks the currently registered global shortcut
+// App state: tracks the currently registered global shortcut and menu items
 // ---------------------------------------------------------------------------
 
 pub struct AppState {
     pub current_shortcut: Mutex<Option<Shortcut>>,
+    pub history_menu_item: Mutex<Option<CheckMenuItem<tauri::Wry>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -321,5 +323,16 @@ pub async fn export_file(
         Some(FilePath::Path(p)) => fs::write(&p, content).map_err(|e| e.to_string()),
         Some(_) => Err("Unsupported file path type".to_string()),
         None => Ok(()), // user cancelled
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Menu state sync
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn set_history_panel_open(state: tauri::State<'_, AppState>, open: bool) {
+    if let Some(item) = state.history_menu_item.lock().unwrap().as_ref() {
+        let _ = item.set_checked(open);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod commands;
 use commands::AppState;
 use std::sync::Mutex;
 use tauri::{
-    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
+    menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::TrayIconBuilder,
     Emitter, Manager,
 };
@@ -21,16 +21,18 @@ pub fn run() {
         ))
         .manage(AppState {
             current_shortcut: Mutex::new(None),
+            history_menu_item: Mutex::new(None),
         })
         .setup(|app| {
             // macOS system menu bar: popmark menu + File menu + View menu + Edit menu
             #[cfg(target_os = "macos")]
             {
-                let menu_toggle_history_item = MenuItem::with_id(
+                let menu_toggle_history_item = CheckMenuItem::with_id(
                     app,
                     "menu-toggle-history",
                     "History",
                     true,
+                    false,
                     Some("cmd+h"),
                 )?;
                 let menu_settings_item = MenuItem::with_id(
@@ -110,6 +112,8 @@ pub fn run() {
                     ],
                 )?;
                 app.set_menu(menu)?;
+                *app.state::<AppState>().history_menu_item.lock().unwrap() =
+                    Some(menu_toggle_history_item);
                 app.on_menu_event(|app, event| match event.id().as_ref() {
                     "menu-toggle-history" => {
                         if let Some(window) = app.get_webview_window("main") {
@@ -216,6 +220,7 @@ pub fn run() {
             commands::get_history_entry,
             commands::get_settings,
             commands::save_settings,
+            commands::set_history_panel_open,
         ])
         .on_window_event(|window, event| {
             // Intercept close request → hide instead of quitting

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -337,6 +337,11 @@ export function MarkdownEditor() {
     setPendingContent(null);
   }, []);
 
+  // Sync history panel open state to the View > History menu item checkmark
+  useEffect(() => {
+    invoke("set_history_panel_open", { open: isHistoryOpen });
+  }, [isHistoryOpen]);
+
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <Toolbar


### PR DESCRIPTION
Closes #19

## Summary
- Added macOS system menu bar: popmark / File / Edit / View
- **popmark menu**: Settings… (⌘,) · Quit (⌘Q)
- **File menu**: New Document (⌘N) · Export… (⌘S) · Copy & Close (⌘Return)
- **Edit menu**: Undo · Redo · Cut · Copy · Paste · Select All (PredefinedMenuItems)
- **View menu**: History (⌘H) as `CheckMenuItem`; checkmark reflects panel open state
- Removed duplicate ⌘N / ⌘Return cases from frontend `keydown` handler
- Added `menu-*` event bridge (menu click → Rust emit → frontend listen → IPC invoke)
- Synced `isHistoryOpen` to menu checkmark via `AppState.history_menu_item` + `set_history_panel_open` IPC command

## Test plan
- [ ] Menu bar shows popmark / File / Edit / View with correct shortcuts
- [ ] File > New Document (⌘N) clears the editor
- [ ] File > Export… (⌘S) opens save dialog
- [ ] File > Copy & Close (⌘Return) copies content and hides window
- [ ] popmark > Settings… (⌘,) opens the settings panel
- [ ] View > History (⌘H) toggles the history panel; checkmark appears when open
- [ ] Toolbar history button also syncs the View > History checkmark
- [ ] Tray > History… opens the panel (open-only); checkmark appears
- [ ] Edit menu items (Undo/Redo/Cut/Copy/Paste/Select All) work in the editor