### PR TITLE
fix: tighten prose spacing and add Shift+Tab to exit level-1 list

### DIFF
--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -1,6 +1,6 @@
 import { $isCodeNode, CodeHighlightNode, CodeNode } from "@lexical/code";
 import { AutoLinkNode, LinkNode } from "@lexical/link";
-import { ListItemNode, ListNode } from "@lexical/list";
+import { $createListNode, $isListItemNode, ListItemNode, ListNode } from "@lexical/list";
 import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
@@ -25,6 +25,7 @@ import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { $getNearestNodeOfType } from "@lexical/utils";
 import {
   $createLineBreakNode,
   $createParagraphNode,
@@ -36,6 +37,7 @@ import {
   type EditorState,
   KEY_ARROW_DOWN_COMMAND,
   KEY_ENTER_COMMAND,
+  KEY_TAB_COMMAND,
 } from "lexical";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HistoryPanel } from "../components/HistoryPanel";
@@ -152,6 +154,63 @@ function CodeExitPlugin() {
         return true;
       },
       COMMAND_PRIORITY_LOW,
+    );
+  }, [editor]);
+  return null;
+}
+
+// Allows exiting list mode by pressing Shift+Tab on a level-1 list item
+function ListShiftTabExitPlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_TAB_COMMAND,
+      (e) => {
+        if (!e?.shiftKey) return false;
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+        const anchorNode = selection.anchor.getNode();
+        const listItem = $getNearestNodeOfType(anchorNode, ListItemNode);
+        if (!listItem) return false;
+        const list = listItem.getParent();
+        if (!(list instanceof ListNode)) return false;
+        // If parent of the list is a ListItemNode, we're nested — let default Shift+Tab handle it
+        if ($isListItemNode(list.getParent())) return false;
+
+        e.preventDefault();
+        editor.update(() => {
+          const para = $createParagraphNode();
+          for (const child of listItem.getChildren()) {
+            para.append(child);
+          }
+          const listChildren = list.getChildren();
+          const itemIndex = listItem.getIndexWithinParent();
+          const afterItems = listChildren.slice(itemIndex + 1);
+
+          if (listChildren.length === 1) {
+            list.replace(para);
+          } else if (itemIndex === 0) {
+            list.insertBefore(para);
+            listItem.remove();
+          } else if (afterItems.length === 0) {
+            list.insertAfter(para);
+            listItem.remove();
+          } else {
+            // Middle: split list — items after go to a new list
+            const newList = $createListNode(list.getListType());
+            for (const item of afterItems) {
+              item.remove();
+              newList.append(item);
+            }
+            list.insertAfter(newList);
+            list.insertAfter(para);
+            listItem.remove();
+          }
+          para.select();
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
     );
   }, [editor]);
   return null;
@@ -371,6 +430,7 @@ export function MarkdownEditor() {
         <ClickableLinkPlugin newTab={false} />
         <CodeEnterPlugin />
         <CodeExitPlugin />
+        <ListShiftTabExitPlugin />
         <EditorPlugins
           setIsHistoryOpen={setIsHistoryOpen}
           onToggleHistory={() => setIsHistoryOpen((v) => !v)}

--- a/src/index.css
+++ b/src/index.css
@@ -1,18 +1,71 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* Reduce prose paragraph spacing for scratchpad use */
+/* Compact spacing: paragraphs */
 .prose :where(p):not(:where([class~="not-prose"] *)) {
-  margin-top: 0.25em;
-  margin-bottom: 0.25em;
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+  line-height: 1.45;
 }
 
-/* Reduce list bullet/marker-to-text spacing */
+/* Compact spacing: headings */
+.prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.3em;
+  margin-bottom: 0.2em;
+}
+
+/* Compact spacing: blockquotes */
+.prose :where(blockquote):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+/* Compact spacing: code blocks */
+.prose :where(pre):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+/* Compact spacing: top-level lists (keeps existing indent override) */
 .prose :where(ul, ol):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
   padding-inline-start: 1.25em;
 }
+
+/* Compact spacing: nested lists */
+.prose :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"] *)) {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+/* Compact spacing: horizontal rules */
+.prose :where(hr):not(:where([class~="not-prose"] *)) {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+/* Fix: Remove gap between bullet/marker and text; tighten list item margins.
+   prose-sm sets padding-inline-start on both li and ul>li/ol>li separately;
+   zero both to eliminate the gap while keeping list indentation from ul/ol. */
 .prose :where(li):not(:where([class~="not-prose"] *)) {
-  padding-inline-start: 0.25em;
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+  padding-inline-start: 0;
+  line-height: 1.4;
+}
+.prose :where(ul > li, ol > li):not(:where([class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+
+/* Fix: Suppress double bullet on Lexical nested list wrapper <li>.
+   Lexical renders indented items as <li><ul><li>text</li></ul></li>;
+   the outer empty li shows an unwanted extra marker.
+   :has() is supported in macOS WKWebView (Safari 16.4+).
+   Checklist li[role="checkbox"] never contains child ul/ol, so unaffected. */
+.prose li:has(> ul):not(:where([class~="not-prose"] *)),
+.prose li:has(> ol):not(:where([class~="not-prose"] *)) {
+  list-style: none;
 }
 
 /* Checklist (task list) styles for Lexical CheckListPlugin */


### PR DESCRIPTION
Closes #24

## Summary
- Tightened vertical margins for all block-level elements (`h1–h6`, `blockquote`, `pre`, `ul`/`ol`, `hr`, `p`, `li`)
- Reduced `line-height` for `p` (1.45) and `li` (1.4) to eliminate excess space from line breaks
- Fixed gap between bullet/number marker and text by zeroing `padding-inline-start` on `li` and `ul > li` / `ol > li`
- Suppressed double-bullet on Lexical nested list wrapper `<li>` using CSS `:has(> ul)` / `:has(> ol)`
- Added `ListShiftTabExitPlugin`: Shift+Tab on a level-1 list item converts it to a paragraph (exits list mode)

## Test plan
- [ ] `npm run tauri dev` — type headings, paragraphs, blockquotes, code blocks, `---` — verify tighter spacing
- [ ] Type `- item` / `1. item` — verify marker is visually close to text
- [ ] Type a list item, press Tab on the next line — verify no double bullet on the first nested item
- [ ] Press Shift+Tab on a level-1 list item — verify it converts to a plain paragraph
- [ ] Press Shift+Tab on a nested (level-2+) list item — verify it un-indents normally (no regression)
- [ ] Type `- [ ] task` — verify checkbox renders and toggles correctly
- [ ] Toggle dark mode — verify appearance is preserved