### PR TITLE
feat: add Clear All button to History panel

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,3 +1,4 @@
+import { confirm } from "@tauri-apps/plugin-dialog";
 import { useEffect, useRef, useState } from "react";
 import type { HistoryEntry } from "../types/history";
 
@@ -8,6 +9,7 @@ interface HistoryPanelProps {
   entries: HistoryEntry[];
   loading: boolean;
   onDeleteEntry: (id: string) => Promise<void>;
+  onClearAll: () => Promise<void>;
 }
 
 function formatTimestamp(iso: string): string {
@@ -106,6 +108,7 @@ export function HistoryPanel({
   entries,
   loading,
   onDeleteEntry,
+  onClearAll,
 }: HistoryPanelProps) {
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -153,14 +156,31 @@ export function HistoryPanel({
         >
           History
         </span>
-        <button
-          type="button"
-          onClick={onClose}
-          className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-default leading-none"
-          title="Close history panel"
-        >
-          ✕
-        </button>
+        <div className="flex items-center gap-2">
+          {entries.length > 0 && (
+            <button
+              type="button"
+              onClick={async () => {
+                const ok = await confirm("Clear all history? This cannot be undone.", {
+                  title: "Clear All History",
+                  kind: "warning",
+                });
+                if (ok) await onClearAll();
+              }}
+              className="text-xs text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 border border-gray-300 dark:border-gray-600 hover:border-red-400 dark:hover:border-red-500 rounded-full px-2 py-0.5 cursor-default transition-colors"
+            >
+              Clear All
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-default leading-none"
+            title="Close history panel"
+          >
+            ✕
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto p-1">

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -1053,6 +1053,7 @@ export function MarkdownEditor({
             entries={entries}
             loading={loading}
             onDeleteEntry={deleteEntry}
+            onClearAll={clearHistory}
           />
         </div>
         <div className="flex justify-end items-center px-3 py-2 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 select-none">


### PR DESCRIPTION
## Background

The History panel supported per-entry deletion via a two-click trash icon pattern, but had no way to bulk-delete all entries at once. The Rust backend already had a `clear_history` IPC command and `useHistory` exposed `clearHistory()`, so the missing piece was purely a UI concern.

## Summary

- Add a pill-shaped "Clear All" text button in the History panel header, visible only when entries exist
- On click, show a native warning confirm dialog before executing the bulk delete
- Wire `clearHistory` from `useHistory` into the new `onClearAll` prop

## Test plan

- [x] `npm run tauri dev`
- [x] Add a few history entries via "Send to Clipboard"
- [x] Open History panel → "Clear All" pill button appears in the header
- [x] Click "Clear All" → native warning confirm dialog appears
- [x] Cancel → nothing changes, entries remain
- [x] Click "Clear All" again → confirm → all entries removed, panel shows "No history yet"
- [x] "Clear All" button is hidden when history is empty