### PR TITLE
refactor: apply Phase 1 quick wins for code clarity

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,12 @@
 mod commands;
 
 use commands::AppState;
+use serde::Serialize;
 use std::sync::Mutex;
 use tauri::{
     menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::TrayIconBuilder,
-    Emitter, Manager, PhysicalPosition,
+    AppHandle, Emitter, Manager, PhysicalPosition,
 };
 use tauri_plugin_autostart::MacosLauncher;
 
@@ -241,30 +242,22 @@ pub fn run() {
                     Some(menu_editor_mode_plain_item);
                 app.on_menu_event(|app, event| match event.id().as_ref() {
                     "menu-toggle-history" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-toggle-history", ());
-                        }
+                        emit_to_main_window(app, "menu-toggle-history", ());
                     }
                     "menu-settings" => {
                         let _ = commands::show_settings_window(app.clone());
                     }
                     "menu-new-document" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-new-document", ());
-                        }
+                        emit_to_main_window(app, "menu-new-document", ());
                     }
                     "menu-export" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-export", ());
-                        }
+                        emit_to_main_window(app, "menu-export", ());
                     }
                     "menu-show-history-folder" => {
                         commands::open_history_folder(app.clone());
                     }
                     "menu-send-to-clipboard" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-send-to-clipboard", ());
-                        }
+                        emit_to_main_window(app, "menu-send-to-clipboard", ());
                     }
                     "menu-move-to-center" => {
                         if let Some(window) = app.get_webview_window("main") {
@@ -294,9 +287,7 @@ pub fn run() {
                         if let Some(item) = state.editor_mode_plain_item.lock().unwrap().as_ref() {
                             let _ = item.set_checked(false);
                         }
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-set-editor-mode", "rich");
-                        }
+                        emit_to_main_window(app, "menu-set-editor-mode", "rich");
                     }
                     "menu-set-editor-mode-plain" => {
                         // Immediately correct checkmarks; macOS auto-toggles on click
@@ -307,34 +298,22 @@ pub fn run() {
                         if let Some(item) = state.editor_mode_plain_item.lock().unwrap().as_ref() {
                             let _ = item.set_checked(true);
                         }
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-set-editor-mode", "plain");
-                        }
+                        emit_to_main_window(app, "menu-set-editor-mode", "plain");
                     }
                     "menu-clear-history" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-clear-history", ());
-                        }
+                        emit_to_main_window(app, "menu-clear-history", ());
                     }
                     "menu-paste-and-match-style" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-paste-and-match-style", ());
-                        }
+                        emit_to_main_window(app, "menu-paste-and-match-style", ());
                     }
                     "menu-paste-from-markdown" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-paste-from-markdown", ());
-                        }
+                        emit_to_main_window(app, "menu-paste-from-markdown", ());
                     }
                     "menu-recall-last" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-recall-last", ());
-                        }
+                        emit_to_main_window(app, "menu-recall-last", ());
                     }
                     "menu-clear-all" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.emit("menu-clear-all", ());
-                        }
+                        emit_to_main_window(app, "menu-clear-all", ());
                     }
                     "menu-help" => {
                         // stub: no help documentation yet
@@ -366,19 +345,11 @@ pub fn run() {
                 .menu(&tray_menu)
                 .on_menu_event(|app, event| match event.id().as_ref() {
                     "show-editor" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.show();
-                            let _ = window.set_focus();
-                            let _ = window.emit("window-shown", ());
-                        }
+                        show_and_focus_main_window(app);
                     }
                     "open-history" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            let _ = window.show();
-                            let _ = window.set_focus();
-                            let _ = window.emit("window-shown", ());
-                            let _ = window.emit("open-history-panel", ());
-                        }
+                        show_and_focus_main_window(app);
+                        emit_to_main_window(app, "open-history-panel", ());
                     }
                     "open-settings" => {
                         let _ = commands::show_settings_window(app.clone());
@@ -465,12 +436,22 @@ pub fn run() {
             } = event
             {
                 if !has_visible_windows {
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                        let _ = window.emit("window-shown", ());
-                    }
+                    show_and_focus_main_window(app_handle);
                 }
             }
         });
+}
+
+fn emit_to_main_window(app: &AppHandle, event: &str, payload: impl Serialize + Clone) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.emit(event, payload);
+    }
+}
+
+fn show_and_focus_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.set_focus();
+        let _ = window.emit("window-shown", ());
+    }
 }

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,4 +1,5 @@
 import { confirm } from "@tauri-apps/plugin-dialog";
+import { Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { HistoryEntry } from "../types/history";
 
@@ -15,24 +16,6 @@ interface HistoryPanelProps {
 function formatTimestamp(iso: string): string {
   // iso: "2024-03-14T09:41:00" → "2024-03-14 09:41"
   return iso.replace("T", " ").slice(0, 16);
-}
-
-function TrashIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      className={className}
-      aria-hidden="true"
-    >
-      <path
-        fillRule="evenodd"
-        d="M5 3.25V4H2.75a.75.75 0 0 0 0 1.5h.3l.815 8.15A1.5 1.5 0 0 0 5.357 15h5.285a1.5 1.5 0 0 0 1.493-1.35l.815-8.15h.3a.75.75 0 0 0 0-1.5H11v-.75A2.25 2.25 0 0 0 8.75 1h-1.5A2.25 2.25 0 0 0 5 3.25Zm2.25-.75a.75.75 0 0 0-.75.75V4h3v-.75a.75.75 0 0 0-.75-.75h-1.5ZM6.05 6a.75.75 0 0 1 .787.713l.275 5.5a.75.75 0 0 1-1.498.075l-.275-5.5A.75.75 0 0 1 6.05 6Zm3.9 0a.75.75 0 0 1 .712.787l-.275 5.5a.75.75 0 0 1-1.498-.075l.275-5.5a.75.75 0 0 1 .786-.711Z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
 }
 
 interface EntryItemProps {
@@ -94,7 +77,7 @@ function EntryItem({
           ].join(" ")}
           title={isPendingDelete ? "Click again to confirm deletion" : "Delete entry"}
         >
-          <TrashIcon className="w-3.5 h-3.5" />
+          <Trash2 className="w-3.5 h-3.5" />
         </button>
       </div>
     </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Settings } from "../types/settings";
 import { codeToHotkeySegment, formatHotkey } from "../utils/hotkey";
 
@@ -59,6 +59,14 @@ export function SettingsPanel() {
     };
   }, []);
 
+  const handleCancel = useCallback(() => {
+    setIsCapturing(false);
+    setCapturedHotkey(savedHotkey);
+    setIsCapturingSend(false);
+    setCapturedSendShortcut(savedSendShortcut);
+    invoke("hide_settings_window");
+  }, [savedHotkey, savedSendShortcut]);
+
   // ESC to cancel (when not capturing)
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -68,7 +76,7 @@ export function SettingsPanel() {
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  });
+  }, [isCapturing, isCapturingSend, handleCancel]);
 
   function startCapture() {
     invoke("set_hotkey_capture_active", { active: true });
@@ -154,14 +162,6 @@ export function SettingsPanel() {
     });
     setSavedHotkey(capturedHotkey);
     setSavedSendShortcut(capturedSendShortcut);
-    invoke("hide_settings_window");
-  }
-
-  function handleCancel() {
-    setIsCapturing(false);
-    setCapturedHotkey(savedHotkey);
-    setIsCapturingSend(false);
-    setCapturedSendShortcut(savedSendShortcut);
     invoke("hide_settings_window");
   }
 

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -1,6 +1,5 @@
-import { $isCodeNode, CodeHighlightNode, CodeNode } from "@lexical/code";
+import { $isCodeNode } from "@lexical/code";
 import { $generateHtmlFromNodes } from "@lexical/html";
-import { AutoLinkNode, LinkNode } from "@lexical/link";
 import { $createListNode, $isListItemNode, ListItemNode, ListNode } from "@lexical/list";
 import {
   $convertFromMarkdownString,
@@ -15,14 +14,12 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
-import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
 import { HorizontalRulePlugin } from "@lexical/react/LexicalHorizontalRulePlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
-import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { $getNearestNodeOfType } from "@lexical/utils";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -56,6 +53,7 @@ import { Toolbar } from "../components/Toolbar";
 import { useHistory } from "../hooks/useHistory";
 import type { Settings } from "../types/settings";
 import { codeToHotkeySegment, formatHotkey } from "../utils/hotkey";
+import { EDITOR_NODES } from "./nodes";
 
 function matchesSendShortcut(e: KeyboardEvent | React.KeyboardEvent, shortcut: string): boolean {
   const parts = shortcut.toLowerCase().split("+");
@@ -86,17 +84,7 @@ const initialConfig = {
       italic: "editor-italic",
     },
   },
-  nodes: [
-    HeadingNode,
-    QuoteNode,
-    CodeNode,
-    CodeHighlightNode,
-    ListNode,
-    ListItemNode,
-    LinkNode,
-    AutoLinkNode,
-    HorizontalRuleNode,
-  ],
+  nodes: EDITOR_NODES,
   onError: (error: Error) => {
     console.error(error);
   },
@@ -644,17 +632,7 @@ function EditorPlugins({
         onPastePlainText(text);
       } else {
         const tempEditor = createEditor({
-          nodes: [
-            HeadingNode,
-            QuoteNode,
-            CodeNode,
-            CodeHighlightNode,
-            ListNode,
-            ListItemNode,
-            LinkNode,
-            AutoLinkNode,
-            HorizontalRuleNode,
-          ],
+          nodes: EDITOR_NODES,
         });
         await new Promise<void>((resolve) => {
           tempEditor.update(

--- a/src/editor/nodes.ts
+++ b/src/editor/nodes.ts
@@ -1,0 +1,17 @@
+import { CodeHighlightNode, CodeNode } from "@lexical/code";
+import { AutoLinkNode, LinkNode } from "@lexical/link";
+import { ListItemNode, ListNode } from "@lexical/list";
+import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+
+export const EDITOR_NODES = [
+  HeadingNode,
+  QuoteNode,
+  CodeNode,
+  CodeHighlightNode,
+  ListNode,
+  ListItemNode,
+  LinkNode,
+  AutoLinkNode,
+  HorizontalRuleNode,
+];


### PR DESCRIPTION
## Background

Issue #103 identified five low-risk, self-contained refactoring opportunities that improve clarity without changing behavior.

## Summary

- Fix missing dependency array in `SettingsPanel.tsx` `useEffect` — convert `handleCancel` to `useCallback` and add proper deps `[isCapturing, isCapturingSend, handleCancel]` to prevent stale closure
- Replace inline `TrashIcon` SVG component in `HistoryPanel.tsx` with `Trash2` from `lucide-react`
- Extract shared Lexical node list to `src/editor/nodes.ts` as `EDITOR_NODES` constant, removing duplication between `initialConfig` and the "Paste from Markdown" temp editor
- Extract `emit_to_main_window` helper in `lib.rs` — replaces 11 repetitions of the `get_webview_window` + `emit` pattern
- Extract `show_and_focus_main_window` helper in `lib.rs` — replaces 3 repetitions of the show + focus + emit `"window-shown"` pattern

Closes #103

## Test plan

- [x] `npm run check:ci` passes
- [x] `cargo check` passes
- [x] `npm run build` succeeds
- [x] Open settings window and press Escape — window should close
- [x] Menu items (New Document, Export, toggle History, etc.) function correctly
- [x] Tray "Show Editor" and "History…" items work
- [x] Paste from Markdown correctly parses Markdown content