### PR TITLE
refactor: extract settings/history helpers and split setup() in lib.rs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use chrono::Local;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri::menu::{CheckMenuItem, MenuItem};
@@ -147,6 +147,44 @@ fn extract_title_preview(content: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Settings persistence helpers
+// ---------------------------------------------------------------------------
+
+fn load_settings_from_disk(app: &AppHandle) -> Result<Settings, String> {
+    let path = settings_path(app)?;
+    if path.exists() {
+        let data = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&data).map_err(|e| e.to_string())
+    } else {
+        Ok(Settings::default())
+    }
+}
+
+fn save_settings_to_disk(app: &AppHandle, settings: &Settings) -> Result<(), String> {
+    let path = settings_path(app)?;
+    let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// History management helpers
+// ---------------------------------------------------------------------------
+
+fn history_file_path(history_dir: &Path, id: &str) -> PathBuf {
+    history_dir.join(format!("{}.md", id))
+}
+
+fn load_history_entries(app: &AppHandle) -> Result<Vec<HistoryEntry>, String> {
+    let history = history_dir(app)?;
+    let index_path = history.join("index.json");
+    if !index_path.exists() {
+        return Ok(Vec::new());
+    }
+    let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&data).map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
 // Data folder opener (menu-only, not an IPC command)
 // ---------------------------------------------------------------------------
 
@@ -208,28 +246,16 @@ pub fn re_register_shortcut(app: &AppHandle, hotkey: &str) -> Result<(), String>
 
 #[tauri::command]
 pub fn get_settings(app: AppHandle) -> Result<Settings, String> {
-    let path = settings_path(&app)?;
-    if path.exists() {
-        let data = fs::read_to_string(&path).map_err(|e| e.to_string())?;
-        serde_json::from_str(&data).map_err(|e| e.to_string())
-    } else {
-        Ok(Settings::default())
-    }
+    load_settings_from_disk(&app)
 }
 
 #[tauri::command]
 pub fn save_settings(app: AppHandle, mut settings: Settings) -> Result<(), String> {
-    // Persist to disk
-    let path = settings_path(&app)?;
     // Preserve the current editor_mode — managed exclusively via save_editor_mode
-    if path.exists() {
-        let data = fs::read_to_string(&path).map_err(|e| e.to_string())?;
-        if let Ok(current) = serde_json::from_str::<Settings>(&data) {
-            settings.editor_mode = current.editor_mode;
-        }
+    if let Ok(current) = load_settings_from_disk(&app) {
+        settings.editor_mode = current.editor_mode;
     }
-    let json = serde_json::to_string_pretty(&settings).map_err(|e| e.to_string())?;
-    fs::write(&path, json).map_err(|e| e.to_string())?;
+    save_settings_to_disk(&app, &settings)?;
 
     // Re-register global shortcut with new hotkey
     re_register_shortcut(&app, &settings.hotkey)?;
@@ -265,16 +291,9 @@ pub fn list_fonts() -> Result<Vec<String>, String> {
 
 #[tauri::command]
 pub fn save_editor_mode(app: AppHandle, mode: String) -> Result<(), String> {
-    let path = settings_path(&app)?;
-    let mut settings: Settings = if path.exists() {
-        let data = fs::read_to_string(&path).map_err(|e| e.to_string())?;
-        serde_json::from_str(&data).map_err(|e| e.to_string())?
-    } else {
-        Settings::default()
-    };
+    let mut settings = load_settings_from_disk(&app)?;
     settings.editor_mode = mode;
-    let json = serde_json::to_string_pretty(&settings).map_err(|e| e.to_string())?;
-    fs::write(&path, json).map_err(|e| e.to_string())
+    save_settings_to_disk(&app, &settings)
 }
 
 // ---------------------------------------------------------------------------
@@ -291,16 +310,10 @@ fn save_history_entry(app: &AppHandle, content: &str) -> Result<(), String> {
     let title_preview = extract_title_preview(content);
 
     let history = history_dir(app)?;
-    let file_path = history.join(format!("{}.md", id));
-    fs::write(&file_path, content).map_err(|e| e.to_string())?;
+    fs::write(&history_file_path(&history, &id), content).map_err(|e| e.to_string())?;
 
     let index_path = history.join("index.json");
-    let mut entries: Vec<HistoryEntry> = if index_path.exists() {
-        let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
-        serde_json::from_str(&data).unwrap_or_default()
-    } else {
-        Vec::new()
-    };
+    let mut entries = load_history_entries(app).unwrap_or_default();
     entries.insert(
         0,
         HistoryEntry {
@@ -311,13 +324,13 @@ fn save_history_entry(app: &AppHandle, content: &str) -> Result<(), String> {
     );
 
     // Apply retention limit
-    let settings = get_settings(app.clone())?;
+    let settings = load_settings_from_disk(app)?;
     if let Some(limit) = settings.max_history_entries {
         if limit > 0 {
             let limit = limit as usize;
             while entries.len() > limit {
                 if let Some(removed) = entries.pop() {
-                    let _ = fs::remove_file(history.join(format!("{}.md", removed.id)));
+                    let _ = fs::remove_file(history_file_path(&history, &removed.id));
                 }
             }
         }
@@ -384,7 +397,7 @@ pub fn copy_to_clipboard(
     }
 
     // 6. Notify user (best-effort; silently ignored if permission denied or DND)
-    let settings = get_settings(app.clone()).unwrap_or_default();
+    let settings = load_settings_from_disk(&app).unwrap_or_default();
     if settings.notify_on_copy {
         let _ = app.notification()
             .builder()
@@ -421,19 +434,13 @@ pub fn new_document(app: AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 pub fn list_history(app: AppHandle) -> Result<Vec<HistoryEntry>, String> {
-    let history = history_dir(&app)?;
-    let index_path = history.join("index.json");
-    if !index_path.exists() {
-        return Ok(Vec::new());
-    }
-    let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
-    serde_json::from_str(&data).map_err(|e| e.to_string())
+    load_history_entries(&app)
 }
 
 #[tauri::command]
 pub fn get_history_entry(app: AppHandle, id: String) -> Result<String, String> {
     let history = history_dir(&app)?;
-    let file_path = history.join(format!("{}.md", id));
+    let file_path = history_file_path(&history, &id);
     if !file_path.exists() {
         return Err(format!("History entry not found: {}", id));
     }
@@ -445,17 +452,12 @@ pub fn delete_history_entry(app: AppHandle, id: String) -> Result<(), String> {
     let history = history_dir(&app)?;
     let index_path = history.join("index.json");
 
-    let mut entries: Vec<HistoryEntry> = if index_path.exists() {
-        let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
-        serde_json::from_str(&data).unwrap_or_default()
-    } else {
-        Vec::new()
-    };
+    let mut entries = load_history_entries(&app).unwrap_or_default();
     entries.retain(|e| e.id != id);
     let json = serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())?;
     fs::write(&index_path, json).map_err(|e| e.to_string())?;
 
-    let _ = fs::remove_file(history.join(format!("{}.md", id)));
+    let _ = fs::remove_file(history_file_path(&history, &id));
 
     Ok(())
 }
@@ -465,12 +467,9 @@ pub fn clear_history(app: AppHandle) -> Result<(), String> {
     let history = history_dir(&app)?;
     let index_path = history.join("index.json");
 
-    if index_path.exists() {
-        let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
-        let entries: Vec<HistoryEntry> = serde_json::from_str(&data).unwrap_or_default();
-        for entry in &entries {
-            let _ = fs::remove_file(history.join(format!("{}.md", entry.id)));
-        }
+    let entries = load_history_entries(&app).unwrap_or_default();
+    for entry in &entries {
+        let _ = fs::remove_file(history_file_path(&history, &entry.id));
     }
 
     fs::write(&index_path, "[]").map_err(|e| e.to_string())?;
@@ -484,13 +483,7 @@ pub fn clear_history(app: AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 pub fn recall_last_history(app: AppHandle) -> Result<String, String> {
-    let history = history_dir(&app)?;
-    let index_path = history.join("index.json");
-    if !index_path.exists() {
-        return Err("No history entries".to_string());
-    }
-    let data = fs::read_to_string(&index_path).map_err(|e| e.to_string())?;
-    let entries: Vec<HistoryEntry> = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+    let entries = load_history_entries(&app)?;
     if entries.is_empty() {
         return Err("No history entries".to_string());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,355 +31,18 @@ pub fn run() {
             recall_last_item: Mutex::new(None),
         })
         .setup(|app| {
-            // macOS system menu bar: popmark menu + File menu + View menu + Edit menu
-            #[cfg(target_os = "macos")]
-            {
-                let menu_toggle_history_item = CheckMenuItem::with_id(
-                    app,
-                    "menu-toggle-history",
-                    "History",
-                    true,
-                    false,
-                    Some("cmd+h"),
-                )?;
-                let saved_mode = commands::get_settings(app.handle().clone())
-                    .unwrap_or_default()
-                    .editor_mode;
-                let is_rich = saved_mode != "plain";
-                let menu_editor_mode_rich_item = CheckMenuItem::with_id(
-                    app,
-                    "menu-set-editor-mode-rich",
-                    "Rich text",
-                    true,
-                    is_rich,
-                    Some("cmd+shift+r"),
-                )?;
-                let menu_editor_mode_plain_item = CheckMenuItem::with_id(
-                    app,
-                    "menu-set-editor-mode-plain",
-                    "Plain text",
-                    true,
-                    !is_rich,
-                    Some("cmd+shift+p"),
-                )?;
-                let menu_editor_mode_submenu = Submenu::with_items(
-                    app,
-                    "Editor Mode",
-                    true,
-                    &[&menu_editor_mode_rich_item, &menu_editor_mode_plain_item],
-                )?;
-                let menu_clear_history_item = MenuItem::with_id(
-                    app,
-                    "menu-clear-history",
-                    "Clear History\u{2026}",
-                    true,
-                    None::<&str>,
-                )?;
-                let menu_settings_item = MenuItem::with_id(
-                    app,
-                    "menu-settings",
-                    "Settings\u{2026}",
-                    true,
-                    Some("cmd+,"),
-                )?;
-                let menu_new_item = MenuItem::with_id(
-                    app,
-                    "menu-new-document",
-                    "New Document",
-                    true,
-                    Some("cmd+n"),
-                )?;
-                let menu_export_item = MenuItem::with_id(
-                    app,
-                    "menu-export",
-                    "Export\u{2026}",
-                    true,
-                    Some("cmd+s"),
-                )?;
-                let menu_show_history_folder_item = MenuItem::with_id(
-                    app,
-                    "menu-show-history-folder",
-                    "Show History Folder in Finder",
-                    true,
-                    None::<&str>,
-                )?;
-                let menu_send_to_clipboard_item = MenuItem::with_id(
-                    app,
-                    "menu-send-to-clipboard",
-                    "Send to Clipboard",
-                    true,
-                    None::<&str>,
-                )?;
-                let menu_move_to_center_item = MenuItem::with_id(
-                    app,
-                    "menu-move-to-center",
-                    "Move to Center",
-                    true,
-                    None::<&str>,
-                )?;
-                let menu_help_item = MenuItem::with_id(
-                    app,
-                    "menu-help",
-                    "Popmark Help",
-                    true,
-                    Some("cmd+?"),
-                )?;
-                let menu = Menu::with_items(
-                    app,
-                    &[
-                        &Submenu::with_items(
-                            app,
-                            "Popmark",
-                            true,
-                            &[
-                                &PredefinedMenuItem::about(app, None, None)?,
-                                &PredefinedMenuItem::separator(app)?,
-                                &menu_settings_item,
-                                &PredefinedMenuItem::separator(app)?,
-                                &PredefinedMenuItem::quit(app, None)?,
-                            ],
-                        )?,
-                        &Submenu::with_items(
-                            app,
-                            "File",
-                            true,
-                            &[
-                                &menu_new_item,
-                                &PredefinedMenuItem::separator(app)?,
-                                &menu_export_item,
-                                &menu_show_history_folder_item,
-                                &PredefinedMenuItem::separator(app)?,
-                                &menu_send_to_clipboard_item,
-                            ],
-                        )?,
-                        {
-                            let menu_paste_and_match_style_item = MenuItem::with_id(
-                                app,
-                                "menu-paste-and-match-style",
-                                "Paste and Match Style",
-                                true,
-                                Some("alt+shift+cmd+v"),
-                            )?;
-                            let menu_paste_from_markdown_item = MenuItem::with_id(
-                                app,
-                                "menu-paste-from-markdown",
-                                "Paste from Markdown",
-                                true,
-                                None::<&str>,
-                            )?;
-                            let menu_recall_last_item = MenuItem::with_id(
-                                app,
-                                "menu-recall-last",
-                                "Recall Last",
-                                false,
-                                Some("cmd+r"),
-                            )?;
-                            *app.state::<AppState>().recall_last_item.lock().unwrap() =
-                                Some(menu_recall_last_item.clone());
-                            let menu_clear_all_item = MenuItem::with_id(
-                                app,
-                                "menu-clear-all",
-                                "Clear All",
-                                true,
-                                Some("cmd+shift+backspace"),
-                            )?;
-                            &Submenu::with_items(
-                                app,
-                                "Edit",
-                                true,
-                                &[
-                                    &PredefinedMenuItem::undo(app, None)?,
-                                    &PredefinedMenuItem::redo(app, None)?,
-                                    &PredefinedMenuItem::separator(app)?,
-                                    &PredefinedMenuItem::cut(app, None)?,
-                                    &PredefinedMenuItem::copy(app, None)?,
-                                    &PredefinedMenuItem::paste(app, None)?,
-                                    &menu_paste_and_match_style_item,
-                                    &menu_paste_from_markdown_item,
-                                    &PredefinedMenuItem::select_all(app, None)?,
-                                    &menu_clear_all_item,
-                                    &PredefinedMenuItem::separator(app)?,
-                                    &menu_recall_last_item,
-                                ],
-                            )?
-                        },
-                        &Submenu::with_items(
-                            app,
-                            "View",
-                            true,
-                            &[
-                                &menu_toggle_history_item,
-                                &menu_editor_mode_submenu,
-                                &PredefinedMenuItem::separator(app)?,
-                                &menu_clear_history_item,
-                            ],
-                        )?,
-                        &Submenu::with_items(
-                            app,
-                            "Window",
-                            true,
-                            &[
-                                &PredefinedMenuItem::minimize(app, None)?,
-                                &PredefinedMenuItem::maximize(app, None)?,
-                                &PredefinedMenuItem::fullscreen(app, None)?,
-                                &menu_move_to_center_item,
-                            ],
-                        )?,
-                        &Submenu::with_items(
-                            app,
-                            "Help",
-                            true,
-                            &[&menu_help_item],
-                        )?,
-                    ],
-                )?;
-                app.set_menu(menu)?;
-                *app.state::<AppState>().history_menu_item.lock().unwrap() =
-                    Some(menu_toggle_history_item);
-                *app.state::<AppState>().editor_mode_rich_item.lock().unwrap() =
-                    Some(menu_editor_mode_rich_item);
-                *app.state::<AppState>().editor_mode_plain_item.lock().unwrap() =
-                    Some(menu_editor_mode_plain_item);
-                app.on_menu_event(|app, event| match event.id().as_ref() {
-                    "menu-toggle-history" => {
-                        emit_to_main_window(app, "menu-toggle-history", ());
-                    }
-                    "menu-settings" => {
-                        let _ = commands::show_settings_window(app.clone());
-                    }
-                    "menu-new-document" => {
-                        emit_to_main_window(app, "menu-new-document", ());
-                    }
-                    "menu-export" => {
-                        emit_to_main_window(app, "menu-export", ());
-                    }
-                    "menu-show-history-folder" => {
-                        commands::open_history_folder(app.clone());
-                    }
-                    "menu-send-to-clipboard" => {
-                        emit_to_main_window(app, "menu-send-to-clipboard", ());
-                    }
-                    "menu-move-to-center" => {
-                        if let Some(window) = app.get_webview_window("main") {
-                            // Do NOT use window.center() here. It delegates to NSWindow.center(),
-                            // which per Apple HIG places the window at an "alert position" in the
-                            // upper half of the screen — not the geometric center. Instead,
-                            // manually compute the center of the work area (menu bar + Dock excluded).
-                            if let (Ok(Some(monitor)), Ok(window_size)) =
-                                (window.current_monitor(), window.outer_size())
-                            {
-                                let work_area = monitor.work_area();
-                                let x = work_area.position.x
-                                    + (work_area.size.width as i32 - window_size.width as i32) / 2;
-                                let y = work_area.position.y
-                                    + (work_area.size.height as i32 - window_size.height as i32)
-                                        / 2;
-                                let _ = window.set_position(PhysicalPosition::new(x, y));
-                            }
-                        }
-                    }
-                    "menu-set-editor-mode-rich" => {
-                        // Immediately correct checkmarks; macOS auto-toggles on click
-                        let state = app.state::<AppState>();
-                        if let Some(item) = state.editor_mode_rich_item.lock().unwrap().as_ref() {
-                            let _ = item.set_checked(true);
-                        }
-                        if let Some(item) = state.editor_mode_plain_item.lock().unwrap().as_ref() {
-                            let _ = item.set_checked(false);
-                        }
-                        emit_to_main_window(app, "menu-set-editor-mode", "rich");
-                    }
-                    "menu-set-editor-mode-plain" => {
-                        // Immediately correct checkmarks; macOS auto-toggles on click
-                        let state = app.state::<AppState>();
-                        if let Some(item) = state.editor_mode_rich_item.lock().unwrap().as_ref() {
-                            let _ = item.set_checked(false);
-                        }
-                        if let Some(item) = state.editor_mode_plain_item.lock().unwrap().as_ref() {
-                            let _ = item.set_checked(true);
-                        }
-                        emit_to_main_window(app, "menu-set-editor-mode", "plain");
-                    }
-                    "menu-clear-history" => {
-                        emit_to_main_window(app, "menu-clear-history", ());
-                    }
-                    "menu-paste-and-match-style" => {
-                        emit_to_main_window(app, "menu-paste-and-match-style", ());
-                    }
-                    "menu-paste-from-markdown" => {
-                        emit_to_main_window(app, "menu-paste-from-markdown", ());
-                    }
-                    "menu-recall-last" => {
-                        emit_to_main_window(app, "menu-recall-last", ());
-                    }
-                    "menu-clear-all" => {
-                        emit_to_main_window(app, "menu-clear-all", ());
-                    }
-                    "menu-help" => {
-                        // stub: no help documentation yet
-                    }
-                    _ => {}
-                });
-            }
+            let handle = app.handle();
 
-            // Tray icon menu: Show Editor + History… + Settings… + Quit
-            let show_item =
-                MenuItem::with_id(app, "show-editor", "Show Editor", true, None::<&str>)?;
-            let history_item =
-                MenuItem::with_id(app, "open-history", "History\u{2026}", true, None::<&str>)?;
-            let settings_item =
-                MenuItem::with_id(app, "open-settings", "Settings\u{2026}", true, None::<&str>)?;
-            let quit_item =
-                MenuItem::with_id(app, "quit-popmark", "Quit Popmark", true, None::<&str>)?;
-            let tray_menu = Menu::with_items(
-                app,
-                &[
-                    &show_item,
-                    &history_item,
-                    &settings_item,
-                    &PredefinedMenuItem::separator(app)?,
-                    &quit_item,
-                ],
-            )?;
-            let mut builder = TrayIconBuilder::new()
-                .menu(&tray_menu)
-                .on_menu_event(|app, event| match event.id().as_ref() {
-                    "show-editor" => {
-                        show_and_focus_main_window(app);
-                    }
-                    "open-history" => {
-                        show_and_focus_main_window(app);
-                        emit_to_main_window(app, "open-history-panel", ());
-                    }
-                    "open-settings" => {
-                        let _ = commands::show_settings_window(app.clone());
-                    }
-                    "quit-popmark" => {
-                        app.exit(0);
-                    }
-                    _ => {}
-                });
             #[cfg(target_os = "macos")]
-            {
-                const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon.png");
-                let img = image::load_from_memory(TRAY_ICON_PNG)
-                    .map_err(|e| e.to_string())?
-                    .into_rgba8();
-                let (width, height) = image::GenericImageView::dimensions(&img);
-                let icon = tauri::image::Image::new_owned(img.into_raw(), width, height);
-                builder = builder.icon(icon).icon_as_template(true);
-            }
-            #[cfg(not(target_os = "macos"))]
-            if let Some(icon) = app.default_window_icon() {
-                builder = builder.icon(icon.clone());
-            }
-            builder.build(app)?;
+            setup_macos_menu(handle)?;
+
+            setup_tray(handle)?;
 
             // Read saved hotkey from settings and register global shortcut
-            let hotkey = commands::get_settings(app.handle().clone())
+            let hotkey = commands::get_settings(handle.clone())
                 .unwrap_or_default()
                 .hotkey;
-            commands::re_register_shortcut(app.handle(), &hotkey)?;
+            commands::re_register_shortcut(handle, &hotkey)?;
 
             Ok(())
         })
@@ -440,6 +103,350 @@ pub fn run() {
                 }
             }
         });
+}
+
+#[cfg(target_os = "macos")]
+fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    let menu_toggle_history_item = CheckMenuItem::with_id(
+        app,
+        "menu-toggle-history",
+        "History",
+        true,
+        false,
+        Some("cmd+h"),
+    )?;
+    let saved_mode = commands::get_settings(app.clone())
+        .unwrap_or_default()
+        .editor_mode;
+    let is_rich = saved_mode != "plain";
+    let menu_editor_mode_rich_item = CheckMenuItem::with_id(
+        app,
+        "menu-set-editor-mode-rich",
+        "Rich text",
+        true,
+        is_rich,
+        Some("cmd+shift+r"),
+    )?;
+    let menu_editor_mode_plain_item = CheckMenuItem::with_id(
+        app,
+        "menu-set-editor-mode-plain",
+        "Plain text",
+        true,
+        !is_rich,
+        Some("cmd+shift+p"),
+    )?;
+    let menu_editor_mode_submenu = Submenu::with_items(
+        app,
+        "Editor Mode",
+        true,
+        &[&menu_editor_mode_rich_item, &menu_editor_mode_plain_item],
+    )?;
+    let menu_clear_history_item = MenuItem::with_id(
+        app,
+        "menu-clear-history",
+        "Clear History\u{2026}",
+        true,
+        None::<&str>,
+    )?;
+    let menu_settings_item = MenuItem::with_id(
+        app,
+        "menu-settings",
+        "Settings\u{2026}",
+        true,
+        Some("cmd+,"),
+    )?;
+    let menu_new_item = MenuItem::with_id(
+        app,
+        "menu-new-document",
+        "New Document",
+        true,
+        Some("cmd+n"),
+    )?;
+    let menu_export_item = MenuItem::with_id(
+        app,
+        "menu-export",
+        "Export\u{2026}",
+        true,
+        Some("cmd+s"),
+    )?;
+    let menu_show_history_folder_item = MenuItem::with_id(
+        app,
+        "menu-show-history-folder",
+        "Show History Folder in Finder",
+        true,
+        None::<&str>,
+    )?;
+    let menu_send_to_clipboard_item = MenuItem::with_id(
+        app,
+        "menu-send-to-clipboard",
+        "Send to Clipboard",
+        true,
+        None::<&str>,
+    )?;
+    let menu_move_to_center_item = MenuItem::with_id(
+        app,
+        "menu-move-to-center",
+        "Move to Center",
+        true,
+        None::<&str>,
+    )?;
+    let menu_help_item = MenuItem::with_id(
+        app,
+        "menu-help",
+        "Popmark Help",
+        true,
+        Some("cmd+?"),
+    )?;
+    let menu_paste_and_match_style_item = MenuItem::with_id(
+        app,
+        "menu-paste-and-match-style",
+        "Paste and Match Style",
+        true,
+        Some("alt+shift+cmd+v"),
+    )?;
+    let menu_paste_from_markdown_item = MenuItem::with_id(
+        app,
+        "menu-paste-from-markdown",
+        "Paste from Markdown",
+        true,
+        None::<&str>,
+    )?;
+    let menu_recall_last_item = MenuItem::with_id(
+        app,
+        "menu-recall-last",
+        "Recall Last",
+        false,
+        Some("cmd+r"),
+    )?;
+    *app.state::<AppState>().recall_last_item.lock().unwrap() =
+        Some(menu_recall_last_item.clone());
+    let menu_clear_all_item = MenuItem::with_id(
+        app,
+        "menu-clear-all",
+        "Clear All",
+        true,
+        Some("cmd+shift+backspace"),
+    )?;
+    let menu = Menu::with_items(
+        app,
+        &[
+            &Submenu::with_items(
+                app,
+                "Popmark",
+                true,
+                &[
+                    &PredefinedMenuItem::about(app, None, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &menu_settings_item,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::quit(app, None)?,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "File",
+                true,
+                &[
+                    &menu_new_item,
+                    &PredefinedMenuItem::separator(app)?,
+                    &menu_export_item,
+                    &menu_show_history_folder_item,
+                    &PredefinedMenuItem::separator(app)?,
+                    &menu_send_to_clipboard_item,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(app, None)?,
+                    &PredefinedMenuItem::redo(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::cut(app, None)?,
+                    &PredefinedMenuItem::copy(app, None)?,
+                    &PredefinedMenuItem::paste(app, None)?,
+                    &menu_paste_and_match_style_item,
+                    &menu_paste_from_markdown_item,
+                    &PredefinedMenuItem::select_all(app, None)?,
+                    &menu_clear_all_item,
+                    &PredefinedMenuItem::separator(app)?,
+                    &menu_recall_last_item,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "View",
+                true,
+                &[
+                    &menu_toggle_history_item,
+                    &menu_editor_mode_submenu,
+                    &PredefinedMenuItem::separator(app)?,
+                    &menu_clear_history_item,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Window",
+                true,
+                &[
+                    &PredefinedMenuItem::minimize(app, None)?,
+                    &PredefinedMenuItem::maximize(app, None)?,
+                    &PredefinedMenuItem::fullscreen(app, None)?,
+                    &menu_move_to_center_item,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Help",
+                true,
+                &[&menu_help_item],
+            )?,
+        ],
+    )?;
+    app.set_menu(menu)?;
+    *app.state::<AppState>().history_menu_item.lock().unwrap() =
+        Some(menu_toggle_history_item);
+    *app.state::<AppState>().editor_mode_rich_item.lock().unwrap() =
+        Some(menu_editor_mode_rich_item);
+    *app.state::<AppState>().editor_mode_plain_item.lock().unwrap() =
+        Some(menu_editor_mode_plain_item);
+    app.on_menu_event(|app, event| match event.id().as_ref() {
+        "menu-toggle-history" => {
+            emit_to_main_window(app, "menu-toggle-history", ());
+        }
+        "menu-settings" => {
+            let _ = commands::show_settings_window(app.clone());
+        }
+        "menu-new-document" => {
+            emit_to_main_window(app, "menu-new-document", ());
+        }
+        "menu-export" => {
+            emit_to_main_window(app, "menu-export", ());
+        }
+        "menu-show-history-folder" => {
+            commands::open_history_folder(app.clone());
+        }
+        "menu-send-to-clipboard" => {
+            emit_to_main_window(app, "menu-send-to-clipboard", ());
+        }
+        "menu-move-to-center" => {
+            if let Some(window) = app.get_webview_window("main") {
+                // Do NOT use window.center() here. It delegates to NSWindow.center(),
+                // which per Apple HIG places the window at an "alert position" in the
+                // upper half of the screen — not the geometric center. Instead,
+                // manually compute the center of the work area (menu bar + Dock excluded).
+                if let (Ok(Some(monitor)), Ok(window_size)) =
+                    (window.current_monitor(), window.outer_size())
+                {
+                    let work_area = monitor.work_area();
+                    let x = work_area.position.x
+                        + (work_area.size.width as i32 - window_size.width as i32) / 2;
+                    let y = work_area.position.y
+                        + (work_area.size.height as i32 - window_size.height as i32)
+                            / 2;
+                    let _ = window.set_position(PhysicalPosition::new(x, y));
+                }
+            }
+        }
+        "menu-set-editor-mode-rich" => {
+            // Immediately correct checkmarks; macOS auto-toggles on click
+            let state = app.state::<AppState>();
+            if let Some(item) = state.editor_mode_rich_item.lock().unwrap().as_ref() {
+                let _ = item.set_checked(true);
+            }
+            if let Some(item) = state.editor_mode_plain_item.lock().unwrap().as_ref() {
+                let _ = item.set_checked(false);
+            }
+            emit_to_main_window(app, "menu-set-editor-mode", "rich");
+        }
+        "menu-set-editor-mode-plain" => {
+            // Immediately correct checkmarks; macOS auto-toggles on click
+            let state = app.state::<AppState>();
+            if let Some(item) = state.editor_mode_rich_item.lock().unwrap().as_ref() {
+                let _ = item.set_checked(false);
+            }
+            if let Some(item) = state.editor_mode_plain_item.lock().unwrap().as_ref() {
+                let _ = item.set_checked(true);
+            }
+            emit_to_main_window(app, "menu-set-editor-mode", "plain");
+        }
+        "menu-clear-history" => {
+            emit_to_main_window(app, "menu-clear-history", ());
+        }
+        "menu-paste-and-match-style" => {
+            emit_to_main_window(app, "menu-paste-and-match-style", ());
+        }
+        "menu-paste-from-markdown" => {
+            emit_to_main_window(app, "menu-paste-from-markdown", ());
+        }
+        "menu-recall-last" => {
+            emit_to_main_window(app, "menu-recall-last", ());
+        }
+        "menu-clear-all" => {
+            emit_to_main_window(app, "menu-clear-all", ());
+        }
+        "menu-help" => {
+            // stub: no help documentation yet
+        }
+        _ => {}
+    });
+    Ok(())
+}
+
+fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    let show_item =
+        MenuItem::with_id(app, "show-editor", "Show Editor", true, None::<&str>)?;
+    let history_item =
+        MenuItem::with_id(app, "open-history", "History\u{2026}", true, None::<&str>)?;
+    let settings_item =
+        MenuItem::with_id(app, "open-settings", "Settings\u{2026}", true, None::<&str>)?;
+    let quit_item =
+        MenuItem::with_id(app, "quit-popmark", "Quit Popmark", true, None::<&str>)?;
+    let tray_menu = Menu::with_items(
+        app,
+        &[
+            &show_item,
+            &history_item,
+            &settings_item,
+            &PredefinedMenuItem::separator(app)?,
+            &quit_item,
+        ],
+    )?;
+    let mut builder = TrayIconBuilder::new()
+        .menu(&tray_menu)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "show-editor" => {
+                show_and_focus_main_window(app);
+            }
+            "open-history" => {
+                show_and_focus_main_window(app);
+                emit_to_main_window(app, "open-history-panel", ());
+            }
+            "open-settings" => {
+                let _ = commands::show_settings_window(app.clone());
+            }
+            "quit-popmark" => {
+                app.exit(0);
+            }
+            _ => {}
+        });
+    #[cfg(target_os = "macos")]
+    {
+        const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon.png");
+        let img = image::load_from_memory(TRAY_ICON_PNG)
+            .map_err(|e| e.to_string())?
+            .into_rgba8();
+        let (width, height) = image::GenericImageView::dimensions(&img);
+        let icon = tauri::image::Image::new_owned(img.into_raw(), width, height);
+        builder = builder.icon(icon).icon_as_template(true);
+    }
+    #[cfg(not(target_os = "macos"))]
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+    builder.build(app)?;
+    Ok(())
 }
 
 fn emit_to_main_window(app: &AppHandle, event: &str, payload: impl Serialize + Clone) {


### PR DESCRIPTION
Closes #104

## Background

`commands.rs` had duplicated read-parse-write cycles for settings (across 3 functions) and duplicated history file path construction (5 occurrences) and index loading (3 occurrences). `lib.rs` had a ~380-line `.setup()` closure mixing macOS menu creation, tray setup, and shortcut registration all inline.

## Summary

- Extract `load_settings_from_disk` / `save_settings_to_disk` helpers in `commands.rs`; use them in `get_settings`, `save_settings`, `save_editor_mode`, and `copy_to_clipboard`
- Extract `history_file_path` / `load_history_entries` helpers in `commands.rs`; use them in `save_history_entry`, `list_history`, `get_history_entry`, `delete_history_entry`, `clear_history`, and `recall_last_history`
- Extract `setup_macos_menu(app: &AppHandle)` from the `.setup()` closure in `lib.rs`
- Extract `setup_tray(app: &AppHandle)` from the `.setup()` closure in `lib.rs`

## Test plan

- [x] `npm run tauri dev`
- [x] Global hotkey shows the editor window
- [x] Copy & Close copies text to clipboard and saves history
- [x] History panel lists, recalls, and deletes entries correctly
- [x] Settings panel reads/writes settings correctly
- [x] Editor mode (rich/plain) toggle persists across restarts
- [x] Tray icon menu items work (Show Editor, History, Settings, Quit)