### PR TITLE
refactor: extract SettingsPanel sub-components and consolidate font state

### DIFF
--- a/src/components/CheckboxSetting.tsx
+++ b/src/components/CheckboxSetting.tsx
@@ -1,0 +1,22 @@
+interface CheckboxSettingProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: React.ReactNode;
+  className?: string;
+}
+
+export function CheckboxSetting({ checked, onChange, label, className }: CheckboxSettingProps) {
+  return (
+    <div className={className}>
+      <label className="flex items-center gap-3 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          className="w-4 h-4 accent-blue-500"
+        />
+        <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+      </label>
+    </div>
+  );
+}

--- a/src/components/FontSettings.tsx
+++ b/src/components/FontSettings.tsx
@@ -1,0 +1,62 @@
+interface FontSettingsProps {
+  mode: "rich" | "plain";
+  fontFamily: string;
+  fontSize: string;
+  fontFallback: boolean;
+  fontList: string[];
+  onFontFamilyChange: (value: string) => void;
+  onFontSizeChange: (value: string) => void;
+  onFontFallbackChange: (value: boolean) => void;
+}
+
+export function FontSettings({
+  mode,
+  fontFamily,
+  fontSize,
+  fontFallback,
+  fontList,
+  onFontFamilyChange,
+  onFontSizeChange,
+  onFontFallbackChange,
+}: FontSettingsProps) {
+  const datalistId = `${mode}-font-family-list`;
+  const title = mode === "rich" ? "Rich Mode Font" : "Plain Mode Font";
+
+  return (
+    <div>
+      <datalist id={datalistId}>
+        {fontList.map((f) => (
+          <option key={f} value={f} />
+        ))}
+      </datalist>
+      <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{title}</p>
+      <div className="flex items-center gap-2 mb-2">
+        <input
+          type="text"
+          list={datalistId}
+          value={fontFamily}
+          onChange={(e) => onFontFamilyChange(e.target.value)}
+          placeholder="Family…"
+          className="flex-1 min-w-0 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
+        />
+        <input
+          type="number"
+          min="1"
+          value={fontSize}
+          onChange={(e) => onFontSizeChange(e.target.value)}
+          placeholder="px"
+          className="w-14 px-2 py-1 text-sm text-right border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
+        />
+      </div>
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={fontFallback}
+          onChange={(e) => onFontFallbackChange(e.target.checked)}
+          className="w-4 h-4 accent-blue-500"
+        />
+        <span className="text-xs text-gray-600 dark:text-gray-400">Append fallback fonts</span>
+      </label>
+    </div>
+  );
+}

--- a/src/components/HotkeyCapture.tsx
+++ b/src/components/HotkeyCapture.tsx
@@ -1,5 +1,5 @@
-import { useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useRef } from "react";
 import { codeToHotkeySegment, formatHotkey } from "../utils/hotkey";
 
 interface HotkeyCaptureProps {

--- a/src/components/HotkeyCapture.tsx
+++ b/src/components/HotkeyCapture.tsx
@@ -1,0 +1,85 @@
+import { useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { codeToHotkeySegment, formatHotkey } from "../utils/hotkey";
+
+interface HotkeyCaptureProps {
+  label: string;
+  captured: string;
+  isCapturing: boolean;
+  onCaptured: (hotkey: string) => void;
+  onCancelCapture: () => void;
+  onStartCapture: () => void;
+  /** Call invoke("set_hotkey_capture_active") when starting/canceling capture */
+  useSystemCapture?: boolean;
+}
+
+export function HotkeyCapture({
+  label,
+  captured,
+  isCapturing,
+  onCaptured,
+  onCancelCapture,
+  onStartCapture,
+  useSystemCapture = false,
+}: HotkeyCaptureProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  function handleStart() {
+    if (useSystemCapture) {
+      invoke("set_hotkey_capture_active", { active: true });
+    }
+    onStartCapture();
+    buttonRef.current?.focus();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.key === "Escape") {
+      if (useSystemCapture) {
+        invoke("set_hotkey_capture_active", { active: false });
+      }
+      onCancelCapture();
+      return;
+    }
+
+    if (["Alt", "Control", "Shift", "Meta", "Super"].includes(e.key)) return;
+
+    const parts: string[] = [];
+    if (e.ctrlKey) parts.push("ctrl");
+    if (e.altKey) parts.push("alt");
+    if (e.shiftKey) parts.push("shift");
+    if (e.metaKey) parts.push("super");
+    parts.push(codeToHotkeySegment(e.code));
+
+    if (useSystemCapture) {
+      invoke("set_hotkey_capture_active", { active: false });
+    }
+    onCaptured(parts.join("+"));
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className="text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">{label}</span>
+      <button
+        ref={buttonRef}
+        type="button"
+        data-capture-box
+        className={[
+          "w-44 px-3 py-1.5 border rounded text-center font-mono text-sm select-none cursor-pointer",
+          isCapturing
+            ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+            : "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:border-gray-400 dark:hover:border-gray-500",
+        ].join(" ")}
+        onClick={isCapturing ? undefined : handleStart}
+        onKeyDown={isCapturing ? handleKeyDown : undefined}
+        aria-label={
+          isCapturing ? "Press the desired key combination" : `Current shortcut: ${captured}`
+        }
+      >
+        {isCapturing ? "Press shortcut…" : formatHotkey(captured)}
+      </button>
+    </div>
+  );
+}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,8 +1,59 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
 import type { Settings } from "../types/settings";
-import { codeToHotkeySegment, formatHotkey } from "../utils/hotkey";
+import { CheckboxSetting } from "./CheckboxSetting";
+import { FontSettings } from "./FontSettings";
+import { HotkeyCapture } from "./HotkeyCapture";
+
+// --- Font state ---
+
+interface FontState {
+  richFontFamily: string;
+  richFontSize: string;
+  richFontFallback: boolean;
+  plainFontFamily: string;
+  plainFontSize: string;
+  plainFontFallback: boolean;
+}
+
+type FontMode = "rich" | "plain";
+
+type FontAction =
+  | { type: "setFamily"; mode: FontMode; value: string }
+  | { type: "setSize"; mode: FontMode; value: string }
+  | { type: "setFallback"; mode: FontMode; value: boolean }
+  | { type: "reset"; state: FontState };
+
+function fontReducer(state: FontState, action: FontAction): FontState {
+  switch (action.type) {
+    case "setFamily":
+      return action.mode === "rich"
+        ? { ...state, richFontFamily: action.value }
+        : { ...state, plainFontFamily: action.value };
+    case "setSize":
+      return action.mode === "rich"
+        ? { ...state, richFontSize: action.value }
+        : { ...state, plainFontSize: action.value };
+    case "setFallback":
+      return action.mode === "rich"
+        ? { ...state, richFontFallback: action.value }
+        : { ...state, plainFontFallback: action.value };
+    case "reset":
+      return action.state;
+  }
+}
+
+const initialFontState: FontState = {
+  richFontFamily: "",
+  richFontSize: "",
+  richFontFallback: true,
+  plainFontFamily: "",
+  plainFontSize: "",
+  plainFontFallback: true,
+};
+
+// --- Component ---
 
 export function SettingsPanel() {
   const [savedHotkey, setSavedHotkey] = useState("alt+m");
@@ -15,15 +66,8 @@ export function SettingsPanel() {
   const [copyAsRichText, setCopyAsRichText] = useState(false);
   const [notifyOnCopy, setNotifyOnCopy] = useState<boolean>(true);
   const [maxHistoryEntries, setMaxHistoryEntries] = useState<string>("");
-  const [richFontFamily, setRichFontFamily] = useState<string>("");
-  const [richFontSize, setRichFontSize] = useState<string>("");
-  const [richFontFallback, setRichFontFallback] = useState<boolean>(true);
-  const [plainFontFamily, setPlainFontFamily] = useState<string>("");
-  const [plainFontSize, setPlainFontSize] = useState<string>("");
-  const [plainFontFallback, setPlainFontFallback] = useState<boolean>(true);
+  const [fontState, dispatchFont] = useReducer(fontReducer, initialFontState);
   const [fontList, setFontList] = useState<string[]>([]);
-  const captureBoxRef = useRef<HTMLButtonElement>(null);
-  const sendCaptureBoxRef = useRef<HTMLButtonElement>(null);
 
   // Load settings on mount and whenever the settings window is shown
   useEffect(() => {
@@ -36,15 +80,20 @@ export function SettingsPanel() {
         setNotifyOnCopy(s.notify_on_copy ?? true);
         const limit = s.max_history_entries;
         setMaxHistoryEntries(limit != null && limit > 0 ? String(limit) : "");
-        setRichFontFamily(s.rich_font_family ?? "");
-        setRichFontSize(s.rich_font_size != null ? String(s.rich_font_size) : "");
-        setRichFontFallback(s.rich_font_fallback ?? false);
-        setPlainFontFamily(s.plain_font_family ?? "");
-        setPlainFontSize(s.plain_font_size != null ? String(s.plain_font_size) : "");
-        setPlainFontFallback(s.plain_font_fallback ?? false);
         const sendShortcut = s.send_shortcut ?? "super+enter";
         setSavedSendShortcut(sendShortcut);
         setCapturedSendShortcut(sendShortcut);
+        dispatchFont({
+          type: "reset",
+          state: {
+            richFontFamily: s.rich_font_family ?? "",
+            richFontSize: s.rich_font_size != null ? String(s.rich_font_size) : "",
+            richFontFallback: s.rich_font_fallback ?? false,
+            plainFontFamily: s.plain_font_family ?? "",
+            plainFontSize: s.plain_font_size != null ? String(s.plain_font_size) : "",
+            plainFontFallback: s.plain_font_fallback ?? false,
+          },
+        });
       });
     }
 
@@ -78,70 +127,10 @@ export function SettingsPanel() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isCapturing, isCapturingSend, handleCancel]);
 
-  function startCapture() {
-    invoke("set_hotkey_capture_active", { active: true });
-    setIsCapturing(true);
-    captureBoxRef.current?.focus();
-  }
-
-  function handleCaptureKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (e.key === "Escape") {
-      invoke("set_hotkey_capture_active", { active: false });
-      setIsCapturing(false);
-      setCapturedHotkey(savedHotkey);
-      return;
-    }
-
-    // Ignore modifier-only presses
-    if (["Alt", "Control", "Shift", "Meta", "Super"].includes(e.key)) return;
-
-    const parts: string[] = [];
-    if (e.ctrlKey) parts.push("ctrl");
-    if (e.altKey) parts.push("alt");
-    if (e.shiftKey) parts.push("shift");
-    if (e.metaKey) parts.push("super");
-    parts.push(codeToHotkeySegment(e.code));
-
-    setCapturedHotkey(parts.join("+"));
-    invoke("set_hotkey_capture_active", { active: false });
-    setIsCapturing(false);
-  }
-
-  function startCaptureSend() {
-    setIsCapturingSend(true);
-    sendCaptureBoxRef.current?.focus();
-  }
-
-  function handleSendCaptureKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (e.key === "Escape") {
-      setIsCapturingSend(false);
-      setCapturedSendShortcut(savedSendShortcut);
-      return;
-    }
-
-    if (["Alt", "Control", "Shift", "Meta", "Super"].includes(e.key)) return;
-
-    const parts: string[] = [];
-    if (e.ctrlKey) parts.push("ctrl");
-    if (e.altKey) parts.push("alt");
-    if (e.shiftKey) parts.push("shift");
-    if (e.metaKey) parts.push("super");
-    parts.push(codeToHotkeySegment(e.code));
-
-    setCapturedSendShortcut(parts.join("+"));
-    setIsCapturingSend(false);
-  }
-
   async function handleSave() {
     const parsedLimit = Number.parseInt(maxHistoryEntries, 10);
-    const parsedRichSize = Number.parseFloat(richFontSize);
-    const parsedPlainSize = Number.parseFloat(plainFontSize);
+    const parsedRichSize = Number.parseFloat(fontState.richFontSize);
+    const parsedPlainSize = Number.parseFloat(fontState.plainFontSize);
     await invoke("save_settings", {
       settings: {
         hotkey: capturedHotkey,
@@ -149,13 +138,14 @@ export function SettingsPanel() {
         copy_as_rich_text: copyAsRichText,
         max_history_entries:
           maxHistoryEntries.trim() !== "" && parsedLimit > 0 ? parsedLimit : null,
-        rich_font_family: richFontFamily.trim() || null,
-        rich_font_size: richFontSize.trim() !== "" && parsedRichSize > 0 ? parsedRichSize : null,
-        rich_font_fallback: richFontFallback,
-        plain_font_family: plainFontFamily.trim() || null,
+        rich_font_family: fontState.richFontFamily.trim() || null,
+        rich_font_size:
+          fontState.richFontSize.trim() !== "" && parsedRichSize > 0 ? parsedRichSize : null,
+        rich_font_fallback: fontState.richFontFallback,
+        plain_font_family: fontState.plainFontFamily.trim() || null,
         plain_font_size:
-          plainFontSize.trim() !== "" && parsedPlainSize > 0 ? parsedPlainSize : null,
-        plain_font_fallback: plainFontFallback,
+          fontState.plainFontSize.trim() !== "" && parsedPlainSize > 0 ? parsedPlainSize : null,
+        plain_font_fallback: fontState.plainFontFallback,
         send_shortcut: capturedSendShortcut,
         notify_on_copy: notifyOnCopy,
       },
@@ -171,101 +161,70 @@ export function SettingsPanel() {
         <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-4">Settings</h2>
 
         {/* Global shortcut */}
-        <div className="flex items-center justify-between gap-4 mb-3">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">
-            Global Shortcut
-          </span>
-          {/* Hotkey capture box: a <button> that turns into a capture target when clicked */}
-          <button
-            ref={captureBoxRef}
-            type="button"
-            data-capture-box
-            className={[
-              "w-44 px-3 py-1.5 border rounded text-center font-mono text-sm select-none cursor-pointer",
-              isCapturing
-                ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
-                : "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:border-gray-400 dark:hover:border-gray-500",
-            ].join(" ")}
-            onClick={isCapturing ? undefined : startCapture}
-            onKeyDown={isCapturing ? handleCaptureKeyDown : undefined}
-            aria-label={
-              isCapturing
-                ? "Press the desired key combination"
-                : `Current shortcut: ${capturedHotkey}`
-            }
-          >
-            {isCapturing ? "Press shortcut…" : formatHotkey(capturedHotkey)}
-          </button>
+        <div className="mb-3">
+          <HotkeyCapture
+            label="Global Shortcut"
+            captured={capturedHotkey}
+            isCapturing={isCapturing}
+            useSystemCapture
+            onStartCapture={() => setIsCapturing(true)}
+            onCaptured={(hotkey) => {
+              setCapturedHotkey(hotkey);
+              setIsCapturing(false);
+            }}
+            onCancelCapture={() => {
+              setIsCapturing(false);
+              setCapturedHotkey(savedHotkey);
+            }}
+          />
         </div>
 
         {/* Send to Clipboard Shortcut */}
-        <div className="flex items-center justify-between gap-4 mb-4">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">
-            Send to Clipboard Shortcut
-          </span>
-          <button
-            ref={sendCaptureBoxRef}
-            type="button"
-            data-capture-box
-            className={[
-              "w-44 px-3 py-1.5 border rounded text-center font-mono text-sm select-none cursor-pointer",
-              isCapturingSend
-                ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
-                : "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 hover:border-gray-400 dark:hover:border-gray-500",
-            ].join(" ")}
-            onClick={isCapturingSend ? undefined : startCaptureSend}
-            onKeyDown={isCapturingSend ? handleSendCaptureKeyDown : undefined}
-            aria-label={
-              isCapturingSend
-                ? "Press the desired key combination"
-                : `Current shortcut: ${capturedSendShortcut}`
-            }
-          >
-            {isCapturingSend ? "Press shortcut…" : formatHotkey(capturedSendShortcut)}
-          </button>
+        <div className="mb-4">
+          <HotkeyCapture
+            label="Send to Clipboard Shortcut"
+            captured={capturedSendShortcut}
+            isCapturing={isCapturingSend}
+            onStartCapture={() => setIsCapturingSend(true)}
+            onCaptured={(hotkey) => {
+              setCapturedSendShortcut(hotkey);
+              setIsCapturingSend(false);
+            }}
+            onCancelCapture={() => {
+              setIsCapturingSend(false);
+              setCapturedSendShortcut(savedSendShortcut);
+            }}
+          />
         </div>
 
         {/* Launch at login */}
-        <div className="mb-3">
-          <label className="flex items-center gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={launchAtLogin}
-              onChange={(e) => setLaunchAtLogin(e.target.checked)}
-              className="w-4 h-4 accent-blue-500"
-            />
-            <span className="text-sm text-gray-700 dark:text-gray-300">Launch at login</span>
-          </label>
-        </div>
+        <CheckboxSetting
+          checked={launchAtLogin}
+          onChange={setLaunchAtLogin}
+          label="Launch at login"
+          className="mb-3"
+        />
 
         {/* Copy as Rich Text */}
-        <div className="mb-3">
-          <label className="flex items-center gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={copyAsRichText}
-              onChange={(e) => setCopyAsRichText(e.target.checked)}
-              className="w-4 h-4 accent-blue-500"
-            />
-            <span className="text-sm text-gray-700 dark:text-gray-300">
+        <CheckboxSetting
+          checked={copyAsRichText}
+          onChange={setCopyAsRichText}
+          label={
+            <>
               Copy as Rich Text{" "}
               <span className="text-xs text-gray-400 dark:text-gray-500">(Rich mode only)</span>
-            </span>
-          </label>
-        </div>
+            </>
+          }
+          className="mb-3"
+        />
 
         {/* Notify on copy */}
-        <div className="mb-4">
-          <label className="flex items-center gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={notifyOnCopy}
-              onChange={(e) => setNotifyOnCopy(e.target.checked)}
-              className="w-4 h-4 accent-blue-500"
-            />
-            <span className="text-sm text-gray-700 dark:text-gray-300">Notify on copy</span>
-          </label>
-        </div>
+        <CheckboxSetting
+          checked={notifyOnCopy}
+          onChange={setNotifyOnCopy}
+          label="Notify on copy"
+          className="mb-4"
+        />
 
         {/* Max history entries */}
         <div className="mb-4">
@@ -287,87 +246,32 @@ export function SettingsPanel() {
 
         {/* Font settings: Rich | Plain in 2 columns */}
         <div className="grid grid-cols-2 gap-4 mb-6">
-          {/* Rich Mode Font */}
-          <div>
-            <datalist id="rich-font-family-list">
-              {fontList.map((f) => (
-                <option key={f} value={f} />
-              ))}
-            </datalist>
-            <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Rich Mode Font
-            </p>
-            <div className="flex items-center gap-2 mb-2">
-              <input
-                type="text"
-                list="rich-font-family-list"
-                value={richFontFamily}
-                onChange={(e) => setRichFontFamily(e.target.value)}
-                placeholder="Family…"
-                className="flex-1 min-w-0 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
-              />
-              <input
-                type="number"
-                min="1"
-                value={richFontSize}
-                onChange={(e) => setRichFontSize(e.target.value)}
-                placeholder="px"
-                className="w-14 px-2 py-1 text-sm text-right border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
-              />
-            </div>
-            <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={richFontFallback}
-                onChange={(e) => setRichFontFallback(e.target.checked)}
-                className="w-4 h-4 accent-blue-500"
-              />
-              <span className="text-xs text-gray-600 dark:text-gray-400">
-                Append fallback fonts
-              </span>
-            </label>
-          </div>
-
-          {/* Plain Mode Font */}
-          <div>
-            <datalist id="plain-font-family-list">
-              {fontList.map((f) => (
-                <option key={f} value={f} />
-              ))}
-            </datalist>
-            <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Plain Mode Font
-            </p>
-            <div className="flex items-center gap-2 mb-2">
-              <input
-                type="text"
-                list="plain-font-family-list"
-                value={plainFontFamily}
-                onChange={(e) => setPlainFontFamily(e.target.value)}
-                placeholder="Family…"
-                className="flex-1 min-w-0 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
-              />
-              <input
-                type="number"
-                min="1"
-                value={plainFontSize}
-                onChange={(e) => setPlainFontSize(e.target.value)}
-                placeholder="px"
-                className="w-14 px-2 py-1 text-sm text-right border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
-              />
-            </div>
-            <label className="flex items-center gap-2 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={plainFontFallback}
-                onChange={(e) => setPlainFontFallback(e.target.checked)}
-                className="w-4 h-4 accent-blue-500"
-              />
-              <span className="text-xs text-gray-600 dark:text-gray-400">
-                Append fallback fonts
-              </span>
-            </label>
-          </div>
+          <FontSettings
+            mode="rich"
+            fontFamily={fontState.richFontFamily}
+            fontSize={fontState.richFontSize}
+            fontFallback={fontState.richFontFallback}
+            fontList={fontList}
+            onFontFamilyChange={(v) => dispatchFont({ type: "setFamily", mode: "rich", value: v })}
+            onFontSizeChange={(v) => dispatchFont({ type: "setSize", mode: "rich", value: v })}
+            onFontFallbackChange={(v) =>
+              dispatchFont({ type: "setFallback", mode: "rich", value: v })
+            }
+          />
+          <FontSettings
+            mode="plain"
+            fontFamily={fontState.plainFontFamily}
+            fontSize={fontState.plainFontSize}
+            fontFallback={fontState.plainFontFallback}
+            fontList={fontList}
+            onFontFamilyChange={(v) =>
+              dispatchFont({ type: "setFamily", mode: "plain", value: v })
+            }
+            onFontSizeChange={(v) => dispatchFont({ type: "setSize", mode: "plain", value: v })}
+            onFontFallbackChange={(v) =>
+              dispatchFont({ type: "setFallback", mode: "plain", value: v })
+            }
+          />
         </div>
       </div>
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -264,9 +264,7 @@ export function SettingsPanel() {
             fontSize={fontState.plainFontSize}
             fontFallback={fontState.plainFontFallback}
             fontList={fontList}
-            onFontFamilyChange={(v) =>
-              dispatchFont({ type: "setFamily", mode: "plain", value: v })
-            }
+            onFontFamilyChange={(v) => dispatchFont({ type: "setFamily", mode: "plain", value: v })}
             onFontSizeChange={(v) => dispatchFont({ type: "setSize", mode: "plain", value: v })}
             onFontFallbackChange={(v) =>
               dispatchFont({ type: "setFallback", mode: "plain", value: v })


### PR DESCRIPTION
## Background

`SettingsPanel.tsx` had 18 `useState` hooks and several repeated inline UI patterns (hotkey capture buttons ×2, font settings blocks ×2, checkboxes ×3). This PR extracts those into reusable components and consolidates font-related state with `useReducer`.

Closes #105. Part of #102.

## Summary

- Add `<CheckboxSetting>` — reusable `label + checkbox` row
- Add `<HotkeyCapture>` — hotkey capture button with `useSystemCapture` flag for global-shortcut vs. send-shortcut distinction
- Add `<FontSettings>` — font family / size / fallback block parameterised by `mode: "rich" | "plain"`
- Refactor `SettingsPanel` to use the three new components; reduce `useState` count from 18 → 11 by grouping font state into a `useReducer`

## Test plan

- [x] `npm run tauri dev`
- [x] Open Settings window → all fields load from saved settings
- [x] Global Shortcut capture: click → press key combo → label updates
- [x] Send to Clipboard Shortcut capture: same flow, no `set_hotkey_capture_active` side-effect
- [x] ESC while not capturing closes the window; ESC while capturing cancels the capture
- [x] Checkboxes (Launch at login / Copy as Rich Text / Notify on copy) toggle correctly
- [x] Font family / size / fallback inputs update and persist after Save
- [x] Cancel discards changes