### PR TITLE
refactor: decompose MarkdownEditor.tsx into focused modules (phase 4)

### DIFF
--- a/src/components/SendToClipboardButton.tsx
+++ b/src/components/SendToClipboardButton.tsx
@@ -1,0 +1,35 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
+import { formatHotkey } from "../utils/hotkey";
+
+export interface SendToClipboardButtonProps {
+  editorMode: "rich" | "plain";
+  plainContent: string;
+  copyAsRichText: boolean;
+  sendShortcut: string;
+}
+
+export function SendToClipboardButton({
+  editorMode,
+  plainContent,
+  copyAsRichText,
+  sendShortcut,
+}: SendToClipboardButtonProps) {
+  const [editor] = useLexicalComposerContext();
+  const { copyToClipboard } = useCopyToClipboard({
+    editorMode,
+    plainContent,
+    copyAsRichText,
+    editor,
+  });
+
+  return (
+    <button
+      type="button"
+      onClick={copyToClipboard}
+      className="bg-blue-500 text-white rounded hover:bg-blue-600 active:bg-blue-700 px-3 py-1.5 text-sm cursor-default"
+    >
+      Send to clipboard ({formatHotkey(sendShortcut)})
+    </button>
+  );
+}

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -1,12 +1,4 @@
-import { $isCodeNode } from "@lexical/code";
-import { $generateHtmlFromNodes } from "@lexical/html";
-import { $createListNode, $isListItemNode, ListItemNode, ListNode } from "@lexical/list";
-import {
-  $convertFromMarkdownString,
-  $convertToMarkdownString,
-  CHECK_LIST,
-  TRANSFORMERS,
-} from "@lexical/markdown";
+import { $convertFromMarkdownString, $convertToMarkdownString } from "@lexical/markdown";
 import { CheckListPlugin } from "@lexical/react/LexicalCheckListPlugin";
 import { ClickableLinkPlugin } from "@lexical/react/LexicalClickableLinkPlugin";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
@@ -20,61 +12,27 @@ import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPl
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
-import { $getNearestNodeOfType } from "@lexical/utils";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { confirm } from "@tauri-apps/plugin-dialog";
-import {
-  $createLineBreakNode,
-  $createParagraphNode,
-  $createTextNode,
-  $getRoot,
-  $getSelection,
-  $insertNodes,
-  $isRangeSelection,
-  $isTextNode,
-  $parseSerializedNode,
-  COMMAND_PRIORITY_HIGH,
-  COMMAND_PRIORITY_LOW,
-  createEditor,
-  type EditorState,
-  HISTORY_PUSH_TAG,
-  IS_CODE,
-  KEY_ARROW_DOWN_COMMAND,
-  KEY_ARROW_RIGHT_COMMAND,
-  KEY_ENTER_COMMAND,
-  KEY_TAB_COMMAND,
-  SELECTION_CHANGE_COMMAND,
-} from "lexical";
+import { $createParagraphNode, $getRoot, HISTORY_PUSH_TAG, type LexicalEditor } from "lexical";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HistoryPanel } from "../components/HistoryPanel";
+import { SendToClipboardButton } from "../components/SendToClipboardButton";
 import { Toolbar } from "../components/Toolbar";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
+import { useEditorDraftSync } from "../hooks/useEditorDraftSync";
 import { useHistory } from "../hooks/useHistory";
-import type { Settings } from "../types/settings";
-import { codeToHotkeySegment, formatHotkey } from "../utils/hotkey";
+import { useMenuEventListeners } from "../hooks/useMenuEventListeners";
+import { matchesSendShortcut } from "../utils/hotkey";
 import { EDITOR_NODES } from "./nodes";
-
-function matchesSendShortcut(e: KeyboardEvent | React.KeyboardEvent, shortcut: string): boolean {
-  const parts = shortcut.toLowerCase().split("+");
-  const key = parts[parts.length - 1];
-  return (
-    e.ctrlKey === parts.includes("ctrl") &&
-    e.altKey === parts.includes("alt") &&
-    e.shiftKey === parts.includes("shift") &&
-    e.metaKey === parts.includes("super") &&
-    (e.key.toLowerCase() === key ||
-      e.code.toLowerCase() === key ||
-      codeToHotkeySegment(e.code) === key)
-  );
-}
-
-// Support both "- [ ] " and "-[ ] " (with or without space between dash and bracket)
-const CUSTOM_CHECK_LIST = {
-  ...CHECK_LIST,
-  regExp: /^(\s*)[-*+]\s?(\[(\s|x)?\])\s/i,
-};
-const CUSTOM_TRANSFORMERS = [CUSTOM_CHECK_LIST, ...TRANSFORMERS];
+import { CodeEnterPlugin } from "./plugins/CodeEnterPlugin";
+import { CodeExitPlugin } from "./plugins/CodeExitPlugin";
+import { InlineCodeEscapePlugin } from "./plugins/InlineCodeEscapePlugin";
+import { InlineCodeFormatResetPlugin } from "./plugins/InlineCodeFormatResetPlugin";
+import { ListShiftTabExitPlugin } from "./plugins/ListShiftTabExitPlugin";
+import { CUSTOM_TRANSFORMERS } from "./transformers";
 
 const initialConfig = {
   namespace: "popmark",
@@ -90,293 +48,12 @@ const initialConfig = {
   },
 };
 
-// Handles Enter key inside code blocks:
-// - Typing "```" then Enter exits the code block
-// - Prevents double-Enter from exiting (built-in CodeNode behavior)
-function CodeEnterPlugin() {
+function EditorRefPlugin({ editorRef }: { editorRef: React.RefObject<LexicalEditor | null> }) {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
-    return editor.registerCommand(
-      KEY_ENTER_COMMAND,
-      (e) => {
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
-        const anchorNode = selection.anchor.getNode();
-
-        // Case 1: cursor is on CodeNode element itself (double-Enter exit would fire)
-        if ($isCodeNode(anchorNode)) {
-          e?.preventDefault();
-          editor.update(() => {
-            // Move cursor back inside the code block to prevent exit
-            const lastDescendant = anchorNode.getLastDescendant();
-            if (lastDescendant && $isTextNode(lastDescendant)) {
-              lastDescendant.select(lastDescendant.getTextContentSize());
-            } else {
-              const lineBreak = $createLineBreakNode();
-              anchorNode.append(lineBreak);
-            }
-          });
-          return true;
-        }
-
-        // Case 2: cursor is inside a code block text node
-        const parent = anchorNode.getParent();
-        if (!$isCodeNode(parent)) return false;
-
-        // "```" on the current line → exit the code block
-        if (anchorNode.getTextContent() === "```") {
-          e?.preventDefault();
-          editor.update(() => {
-            anchorNode.remove();
-            const para = $createParagraphNode();
-            parent.insertAfter(para);
-            para.select();
-          });
-          return true;
-        }
-
-        return false;
-      },
-      COMMAND_PRIORITY_HIGH,
-    );
-  }, [editor]);
+    editorRef.current = editor;
+  }, [editor, editorRef]);
   return null;
-}
-
-// Allows exiting a code block by pressing ArrowDown at the last line
-function CodeExitPlugin() {
-  const [editor] = useLexicalComposerContext();
-  useEffect(() => {
-    return editor.registerCommand(
-      KEY_ARROW_DOWN_COMMAND,
-      (e) => {
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
-        const anchorNode = selection.anchor.getNode();
-        const parent = anchorNode.getParent();
-        if (!$isCodeNode(parent)) return false;
-        if (anchorNode !== parent.getLastChild()) return false;
-        if (selection.anchor.offset < anchorNode.getTextContentSize()) return false;
-        e?.preventDefault();
-        editor.update(() => {
-          const para = $createParagraphNode();
-          parent.insertAfter(para);
-          para.select();
-        });
-        return true;
-      },
-      COMMAND_PRIORITY_LOW,
-    );
-  }, [editor]);
-  return null;
-}
-
-// Allows exiting list mode by pressing Shift+Tab on a level-1 list item
-function ListShiftTabExitPlugin() {
-  const [editor] = useLexicalComposerContext();
-  useEffect(() => {
-    return editor.registerCommand(
-      KEY_TAB_COMMAND,
-      (e) => {
-        if (!e?.shiftKey) return false;
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
-        const anchorNode = selection.anchor.getNode();
-        const listItem = $getNearestNodeOfType(anchorNode, ListItemNode);
-        if (!listItem) return false;
-        const list = listItem.getParent();
-        if (!(list instanceof ListNode)) return false;
-        // If parent of the list is a ListItemNode, we're nested — let default Shift+Tab handle it
-        if ($isListItemNode(list.getParent())) return false;
-
-        e.preventDefault();
-        editor.update(() => {
-          const para = $createParagraphNode();
-          for (const child of listItem.getChildren()) {
-            para.append(child);
-          }
-          const listChildren = list.getChildren();
-          const itemIndex = listItem.getIndexWithinParent();
-          const afterItems = listChildren.slice(itemIndex + 1);
-
-          if (listChildren.length === 1) {
-            list.replace(para);
-          } else if (itemIndex === 0) {
-            list.insertBefore(para);
-            listItem.remove();
-          } else if (afterItems.length === 0) {
-            list.insertAfter(para);
-            listItem.remove();
-          } else {
-            // Middle: split list — items after go to a new list
-            const newList = $createListNode(list.getListType());
-            for (const item of afterItems) {
-              item.remove();
-              newList.append(item);
-            }
-            list.insertAfter(newList);
-            list.insertAfter(para);
-            listItem.remove();
-          }
-          para.select();
-        });
-        return true;
-      },
-      COMMAND_PRIORITY_HIGH,
-    );
-  }, [editor]);
-  return null;
-}
-
-// Prevents IS_CODE from sticking in two scenarios:
-// 1. Editor becomes empty: Lexical skips format-reset when root text is empty, so new
-//    input would appear inside a code span with no escape. Clear IS_CODE on every
-//    SELECTION_CHANGE while the editor is empty.
-// 2. Cursor at right boundary of an IS_CODE TextNode: after MarkdownShortcutPlugin
-//    fires and the user navigates away then back, IS_CODE re-derives from the anchor
-//    node. Clear it when the cursor is at offset === textContentSize and the next
-//    sibling is not also IS_CODE, so the next keypress inserts plain text outside.
-function InlineCodeFormatResetPlugin() {
-  const [editor] = useLexicalComposerContext();
-  useEffect(() => {
-    return editor.registerCommand(
-      SELECTION_CHANGE_COMMAND,
-      () => {
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
-
-        // Case 1: editor is empty
-        if ($getRoot().getTextContent() === "") {
-          if (selection.format & IS_CODE) {
-            selection.format &= ~IS_CODE;
-            selection.dirty = true;
-          }
-          return false;
-        }
-
-        // Case 2: cursor at right boundary of an IS_CODE TextNode
-        const anchor = selection.anchor;
-        const anchorNode = anchor.getNode();
-        if (
-          $isTextNode(anchorNode) &&
-          anchorNode.getFormat() & IS_CODE &&
-          anchor.offset === anchorNode.getTextContentSize()
-        ) {
-          const next = anchorNode.getNextSibling();
-          if (next === null || !($isTextNode(next) && next.getFormat() & IS_CODE)) {
-            selection.format &= ~IS_CODE;
-            selection.dirty = true;
-          }
-        }
-
-        return false;
-      },
-      COMMAND_PRIORITY_LOW,
-    );
-  }, [editor]);
-  return null;
-}
-
-// Returns the IS_CODE TextNode if the cursor is at its right boundary AND it is the very
-// last node in the editor (i.e. no text follows the code span). Must be called inside a
-// Lexical read or update context.
-function $getTrailingCodeEndNode() {
-  const selection = $getSelection();
-  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
-  const anchor = selection.anchor;
-  const anchorNode = anchor.getNode();
-  if (!$isTextNode(anchorNode)) return null;
-  if (!(anchorNode.getFormat() & IS_CODE)) return null;
-  if (anchor.offset !== anchorNode.getTextContentSize()) return null;
-  if ($getRoot().getLastDescendant() !== anchorNode) return null;
-  return anchorNode;
-}
-
-// When the cursor is at the right end of an inline code span that is also the last node
-// in the editor, pressing → or ` inserts a plain-text space and moves the cursor there.
-// This gives visible feedback that the cursor has escaped the code span.
-function InlineCodeEscapePlugin() {
-  const [editor] = useLexicalComposerContext();
-  useEffect(() => {
-    const insertEscapeSpace = () => {
-      editor.update(() => {
-        const node = $getTrailingCodeEndNode();
-        if (!node) return;
-        const spaceNode = $createTextNode(" ");
-        node.insertAfter(spaceNode);
-        spaceNode.select(1, 1);
-      });
-    };
-
-    const unregisterArrowRight = editor.registerCommand(
-      KEY_ARROW_RIGHT_COMMAND,
-      (e) => {
-        if (!$getTrailingCodeEndNode()) return false;
-        e?.preventDefault();
-        insertEscapeSpace();
-        return true;
-      },
-      COMMAND_PRIORITY_HIGH,
-    );
-
-    // Backtick is not a named Lexical command; intercept at the DOM level
-    const root = editor.getRootElement();
-    const handleBacktick = (e: KeyboardEvent) => {
-      if (e.key !== "`" || e.metaKey || e.ctrlKey || e.altKey) return;
-      let shouldHandle = false;
-      editor.getEditorState().read(() => {
-        shouldHandle = $getTrailingCodeEndNode() !== null;
-      });
-      if (!shouldHandle) return;
-      e.preventDefault();
-      insertEscapeSpace();
-    };
-    root?.addEventListener("keydown", handleBacktick);
-
-    return () => {
-      unregisterArrowRight();
-      root?.removeEventListener("keydown", handleBacktick);
-    };
-  }, [editor]);
-  return null;
-}
-
-interface SendToClipboardButtonProps {
-  editorMode: "rich" | "plain";
-  plainContent: string;
-  copyAsRichText: boolean;
-  sendShortcut: string;
-}
-
-function SendToClipboardButton({
-  editorMode,
-  plainContent,
-  copyAsRichText,
-  sendShortcut,
-}: SendToClipboardButtonProps) {
-  const [editor] = useLexicalComposerContext();
-
-  function handleClick() {
-    if (editorMode === "plain") {
-      invoke("copy_to_clipboard", { content: plainContent });
-    } else {
-      editor.getEditorState().read(() => {
-        const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
-        const htmlContent = copyAsRichText ? $generateHtmlFromNodes(editor) : undefined;
-        invoke("copy_to_clipboard", { content, htmlContent });
-      });
-    }
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className="bg-blue-500 text-white rounded hover:bg-blue-600 active:bg-blue-700 px-3 py-1.5 text-sm cursor-default"
-    >
-      Send to clipboard ({formatHotkey(sendShortcut)})
-    </button>
-  );
 }
 
 interface EditorPluginsProps {
@@ -424,59 +101,19 @@ function EditorPlugins({
   textareaRef,
 }: EditorPluginsProps) {
   const [editor] = useLexicalComposerContext();
-  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const prevEditorModeRef = useRef(editorMode);
-
-  const loadDraftForMode = useCallback(
-    (mode: "rich" | "plain") => {
-      invoke<string>("get_draft").then((content) => {
-        if (mode === "plain") {
-          setPlainContent(content ?? "");
-        } else {
-          editor.update(() => {
-            $convertFromMarkdownString(content ?? "", CUSTOM_TRANSFORMERS);
-          });
-        }
-      });
-    },
-    [editor, setPlainContent],
-  );
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally runs only on mount
-  useEffect(() => {
-    loadDraftForMode(editorMode);
-  }, []);
-
-  // Reload editor after new_document IPC clears the draft
-  useEffect(() => {
-    if (newDocTrigger === 0) return;
-    loadDraftForMode(editorMode);
-  }, [newDocTrigger, loadDraftForMode, editorMode]);
-
-  // Reload draft and auto-focus editor when the window is shown via global shortcut or tray
-  useEffect(() => {
-    const unlisten = listen("window-shown", () => {
-      loadDraftForMode(editorMode);
-      if (editorMode === "rich") {
-        editor.focus();
-      } else {
-        onFocusPlain();
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [editor, editorMode, loadDraftForMode, onFocusPlain]);
-
-  // Load plainContent into editor when switching plain → rich
-  useEffect(() => {
-    if (prevEditorModeRef.current === "plain" && editorMode === "rich") {
-      editor.update(() => {
-        $convertFromMarkdownString(plainContent, CUSTOM_TRANSFORMERS);
-      });
-    }
-    prevEditorModeRef.current = editorMode;
-  }, [editorMode, editor, plainContent]);
+  const { copyToClipboard } = useCopyToClipboard({
+    editorMode,
+    plainContent,
+    copyAsRichText,
+    editor,
+  });
+  const { handleChange } = useEditorDraftSync({
+    editorMode,
+    plainContent,
+    setPlainContent,
+    newDocTrigger,
+    onFocusPlain,
+  });
 
   const handleModeToggle = useCallback(() => {
     if (editorMode === "rich") {
@@ -515,6 +152,21 @@ function EditorPlugins({
     }
   }, [editor, editorMode, textareaRef]);
 
+  useMenuEventListeners({
+    editorMode,
+    plainContent,
+    copyAsRichText,
+    setCopyAsRichText,
+    setSendShortcut,
+    setIsHistoryOpen,
+    onToggleHistory,
+    onClearHistory,
+    onNew,
+    onPastePlainText,
+    handleModeToggle,
+    handleClearAll,
+  });
+
   // Keep the ref in sync so Toolbar and textarea keydown can call it
   useEffect(() => {
     modeToggleFnRef.current = handleModeToggle;
@@ -526,11 +178,7 @@ function EditorPlugins({
         // Plain mode handles the shortcut in the textarea's onKeyDown
         if (editorMode === "plain") return;
         e.preventDefault();
-        editor.getEditorState().read(() => {
-          const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
-          const htmlContent = copyAsRichText ? $generateHtmlFromNodes(editor) : undefined;
-          invoke("copy_to_clipboard", { content, htmlContent });
-        });
+        copyToClipboard();
         return;
       }
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "Backspace") {
@@ -545,168 +193,7 @@ function EditorPlugins({
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [editor, editorMode, copyAsRichText, sendShortcut, handleClearAll]);
-
-  // Listen for menu bar "New Document" event
-  useEffect(() => {
-    const unlisten = listen("menu-new-document", () => {
-      onNew();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [onNew]);
-
-  // Listen for Edit > Clear All menu event
-  useEffect(() => {
-    const unlisten = listen("menu-clear-all", () => {
-      handleClearAll();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [handleClearAll]);
-
-  // Listen for menu bar "Export…" event
-  useEffect(() => {
-    const unlisten = listen("menu-export", () => {
-      if (editorMode === "plain") {
-        invoke("export_file", { content: plainContent, defaultName: "note.md" });
-      } else {
-        editor.getEditorState().read(() => {
-          const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
-          invoke("export_file", { content, defaultName: "note.md" });
-        });
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [editor, editorMode, plainContent]);
-
-  // Listen for menu bar "Send to Clipboard" event
-  useEffect(() => {
-    const unlisten = listen("menu-send-to-clipboard", () => {
-      if (editorMode === "plain") {
-        invoke("copy_to_clipboard", { content: plainContent });
-      } else {
-        editor.getEditorState().read(() => {
-          const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
-          const htmlContent = copyAsRichText ? $generateHtmlFromNodes(editor) : undefined;
-          invoke("copy_to_clipboard", { content, htmlContent });
-        });
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [editor, editorMode, plainContent, copyAsRichText]);
-
-  // Listen for "Paste and Match Style" menu event
-  useEffect(() => {
-    const unlisten = listen("menu-paste-and-match-style", async () => {
-      const text = await invoke<string>("read_clipboard_text").catch(() => null);
-      if (text == null) return;
-      if (editorMode === "plain") {
-        onPastePlainText(text);
-      } else {
-        editor.update(() => {
-          const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            selection.insertText(text);
-          }
-        });
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [editor, editorMode, onPastePlainText]);
-
-  // Listen for "Paste from Markdown" menu event
-  useEffect(() => {
-    const unlisten = listen("menu-paste-from-markdown", async () => {
-      const text = await invoke<string>("read_clipboard_text").catch(() => null);
-      if (!text) return;
-      if (editorMode === "plain") {
-        onPastePlainText(text);
-      } else {
-        const tempEditor = createEditor({
-          nodes: EDITOR_NODES,
-        });
-        await new Promise<void>((resolve) => {
-          tempEditor.update(
-            () => {
-              $convertFromMarkdownString(text, CUSTOM_TRANSFORMERS);
-            },
-            { onUpdate: resolve },
-          );
-        });
-        const { root } = tempEditor.getEditorState().toJSON();
-        const serializedNodes = root.children;
-        editor.update(() => {
-          $insertNodes(serializedNodes.map((json) => $parseSerializedNode(json)));
-        });
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [editor, editorMode, onPastePlainText]);
-
-  // Listen for "open-history-panel" event emitted by the tray menu (open-only)
-  useEffect(() => {
-    const unlisten = listen("open-history-panel", () => {
-      setIsHistoryOpen(true);
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [setIsHistoryOpen]);
-
-  // Listen for menu bar View > History toggle event
-  useEffect(() => {
-    const unlisten = listen("menu-toggle-history", () => {
-      onToggleHistory();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [onToggleHistory]);
-
-  // Listen for menu bar View > Editor Mode submenu events (⌘⇧M via native menu)
-  useEffect(() => {
-    const unlisten = listen<string>("menu-set-editor-mode", (event) => {
-      const targetMode = event.payload as "rich" | "plain";
-      if (targetMode === editorMode) return;
-      handleModeToggle();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [handleModeToggle, editorMode]);
-
-  // Listen for View > Clear History… menu event
-  useEffect(() => {
-    const unlisten = listen("menu-clear-history", () => {
-      onClearHistory();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [onClearHistory]);
-
-  // Listen for settings-changed event emitted by the backend after save_settings
-  useEffect(() => {
-    const unlisten = listen<Settings>("settings-changed", (event) => {
-      setCopyAsRichText(event.payload.copy_as_rich_text ?? false);
-      setSendShortcut(event.payload.send_shortcut ?? "super+enter");
-      // editor_mode not handled here — managed via handleModeToggle / save_editor_mode
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [setCopyAsRichText, setSendShortcut]);
+  }, [copyToClipboard, editorMode, sendShortcut, handleClearAll]);
 
   // Load a pending history entry into the editor or textarea
   useEffect(() => {
@@ -776,17 +263,6 @@ function EditorPlugins({
     textareaRef,
   ]);
 
-  function handleChange(editorState: EditorState) {
-    if (editorMode === "plain") return;
-    if (debounceTimer.current) clearTimeout(debounceTimer.current);
-    debounceTimer.current = setTimeout(() => {
-      editorState.read(() => {
-        const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
-        invoke("save_draft", { content });
-      });
-    }, 500);
-  }
-
   return <OnChangePlugin onChange={handleChange} />;
 }
 
@@ -817,6 +293,13 @@ export function MarkdownEditor({
   const modeToggleFnRef = useRef<(() => void) | null>(null);
   const plainDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<LexicalEditor | null>(null);
+  const { copyToClipboard } = useCopyToClipboard({
+    editorMode,
+    plainContent,
+    copyAsRichText,
+    editor: editorRef.current,
+  });
 
   // Load settings on mount
   useEffect(() => {
@@ -937,7 +420,7 @@ export function MarkdownEditor({
   function handlePlainKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (matchesSendShortcut(e, sendShortcut)) {
       e.preventDefault();
-      invoke("copy_to_clipboard", { content: plainContent });
+      copyToClipboard();
       return;
     }
     // Escape and Ctrl+Shift+M are handled by window-level listener in EditorPlugins
@@ -1003,6 +486,7 @@ export function MarkdownEditor({
               <InlineCodeEscapePlugin />
             </>
           )}
+          <EditorRefPlugin editorRef={editorRef} />
           <EditorPlugins
             setIsHistoryOpen={setIsHistoryOpen}
             onToggleHistory={() => setIsHistoryOpen((v) => !v)}

--- a/src/editor/plugins/CodeEnterPlugin.tsx
+++ b/src/editor/plugins/CodeEnterPlugin.tsx
@@ -1,0 +1,65 @@
+import { $isCodeNode } from "@lexical/code";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_HIGH,
+  KEY_ENTER_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+// Handles Enter key inside code blocks:
+// - Typing "```" then Enter exits the code block
+// - Prevents double-Enter from exiting (built-in CodeNode behavior)
+export function CodeEnterPlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (e) => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+        const anchorNode = selection.anchor.getNode();
+
+        // Case 1: cursor is on CodeNode element itself (double-Enter exit would fire)
+        if ($isCodeNode(anchorNode)) {
+          e?.preventDefault();
+          editor.update(() => {
+            // Move cursor back inside the code block to prevent exit
+            const lastDescendant = anchorNode.getLastDescendant();
+            if (lastDescendant && $isTextNode(lastDescendant)) {
+              lastDescendant.select(lastDescendant.getTextContentSize());
+            } else {
+              const lineBreak = $createLineBreakNode();
+              anchorNode.append(lineBreak);
+            }
+          });
+          return true;
+        }
+
+        // Case 2: cursor is inside a code block text node
+        const parent = anchorNode.getParent();
+        if (!$isCodeNode(parent)) return false;
+
+        // "```" on the current line → exit the code block
+        if (anchorNode.getTextContent() === "```") {
+          e?.preventDefault();
+          editor.update(() => {
+            anchorNode.remove();
+            const para = $createParagraphNode();
+            parent.insertAfter(para);
+            para.select();
+          });
+          return true;
+        }
+
+        return false;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor]);
+  return null;
+}

--- a/src/editor/plugins/CodeExitPlugin.tsx
+++ b/src/editor/plugins/CodeExitPlugin.tsx
@@ -1,0 +1,38 @@
+import { $isCodeNode } from "@lexical/code";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  KEY_ARROW_DOWN_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+// Allows exiting a code block by pressing ArrowDown at the last line
+export function CodeExitPlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ARROW_DOWN_COMMAND,
+      (e) => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+        const anchorNode = selection.anchor.getNode();
+        const parent = anchorNode.getParent();
+        if (!$isCodeNode(parent)) return false;
+        if (anchorNode !== parent.getLastChild()) return false;
+        if (selection.anchor.offset < anchorNode.getTextContentSize()) return false;
+        e?.preventDefault();
+        editor.update(() => {
+          const para = $createParagraphNode();
+          parent.insertAfter(para);
+          para.select();
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  }, [editor]);
+  return null;
+}

--- a/src/editor/plugins/InlineCodeEscapePlugin.tsx
+++ b/src/editor/plugins/InlineCodeEscapePlugin.tsx
@@ -1,0 +1,76 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_HIGH,
+  IS_CODE,
+  KEY_ARROW_RIGHT_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+// Returns the IS_CODE TextNode if the cursor is at its right boundary AND it is the very
+// last node in the editor (i.e. no text follows the code span). Must be called inside a
+// Lexical read or update context.
+function $getTrailingCodeEndNode() {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
+  const anchor = selection.anchor;
+  const anchorNode = anchor.getNode();
+  if (!$isTextNode(anchorNode)) return null;
+  if (!(anchorNode.getFormat() & IS_CODE)) return null;
+  if (anchor.offset !== anchorNode.getTextContentSize()) return null;
+  if ($getRoot().getLastDescendant() !== anchorNode) return null;
+  return anchorNode;
+}
+
+// When the cursor is at the right end of an inline code span that is also the last node
+// in the editor, pressing → or ` inserts a plain-text space and moves the cursor there.
+// This gives visible feedback that the cursor has escaped the code span.
+export function InlineCodeEscapePlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    const insertEscapeSpace = () => {
+      editor.update(() => {
+        const node = $getTrailingCodeEndNode();
+        if (!node) return;
+        const spaceNode = $createTextNode(" ");
+        node.insertAfter(spaceNode);
+        spaceNode.select(1, 1);
+      });
+    };
+
+    const unregisterArrowRight = editor.registerCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      (e) => {
+        if (!$getTrailingCodeEndNode()) return false;
+        e?.preventDefault();
+        insertEscapeSpace();
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+
+    // Backtick is not a named Lexical command; intercept at the DOM level
+    const root = editor.getRootElement();
+    const handleBacktick = (e: KeyboardEvent) => {
+      if (e.key !== "`" || e.metaKey || e.ctrlKey || e.altKey) return;
+      let shouldHandle = false;
+      editor.getEditorState().read(() => {
+        shouldHandle = $getTrailingCodeEndNode() !== null;
+      });
+      if (!shouldHandle) return;
+      e.preventDefault();
+      insertEscapeSpace();
+    };
+    root?.addEventListener("keydown", handleBacktick);
+
+    return () => {
+      unregisterArrowRight();
+      root?.removeEventListener("keydown", handleBacktick);
+    };
+  }, [editor]);
+  return null;
+}

--- a/src/editor/plugins/InlineCodeFormatResetPlugin.tsx
+++ b/src/editor/plugins/InlineCodeFormatResetPlugin.tsx
@@ -1,0 +1,60 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_LOW,
+  IS_CODE,
+  SELECTION_CHANGE_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+// Prevents IS_CODE from sticking in two scenarios:
+// 1. Editor becomes empty: Lexical skips format-reset when root text is empty, so new
+//    input would appear inside a code span with no escape. Clear IS_CODE on every
+//    SELECTION_CHANGE while the editor is empty.
+// 2. Cursor at right boundary of an IS_CODE TextNode: after MarkdownShortcutPlugin
+//    fires and the user navigates away then back, IS_CODE re-derives from the anchor
+//    node. Clear it when the cursor is at offset === textContentSize and the next
+//    sibling is not also IS_CODE, so the next keypress inserts plain text outside.
+export function InlineCodeFormatResetPlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    return editor.registerCommand(
+      SELECTION_CHANGE_COMMAND,
+      () => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+
+        // Case 1: editor is empty
+        if ($getRoot().getTextContent() === "") {
+          if (selection.format & IS_CODE) {
+            selection.format &= ~IS_CODE;
+            selection.dirty = true;
+          }
+          return false;
+        }
+
+        // Case 2: cursor at right boundary of an IS_CODE TextNode
+        const anchor = selection.anchor;
+        const anchorNode = anchor.getNode();
+        if (
+          $isTextNode(anchorNode) &&
+          anchorNode.getFormat() & IS_CODE &&
+          anchor.offset === anchorNode.getTextContentSize()
+        ) {
+          const next = anchorNode.getNextSibling();
+          if (next === null || !($isTextNode(next) && next.getFormat() & IS_CODE)) {
+            selection.format &= ~IS_CODE;
+            selection.dirty = true;
+          }
+        }
+
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  }, [editor]);
+  return null;
+}

--- a/src/editor/plugins/ListShiftTabExitPlugin.tsx
+++ b/src/editor/plugins/ListShiftTabExitPlugin.tsx
@@ -1,0 +1,68 @@
+import { $createListNode, $isListItemNode, ListItemNode, ListNode } from "@lexical/list";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getNearestNodeOfType } from "@lexical/utils";
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_HIGH,
+  KEY_TAB_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+// Allows exiting list mode by pressing Shift+Tab on a level-1 list item
+export function ListShiftTabExitPlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_TAB_COMMAND,
+      (e) => {
+        if (!e?.shiftKey) return false;
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+        const anchorNode = selection.anchor.getNode();
+        const listItem = $getNearestNodeOfType(anchorNode, ListItemNode);
+        if (!listItem) return false;
+        const list = listItem.getParent();
+        if (!(list instanceof ListNode)) return false;
+        // If parent of the list is a ListItemNode, we're nested — let default Shift+Tab handle it
+        if ($isListItemNode(list.getParent())) return false;
+
+        e.preventDefault();
+        editor.update(() => {
+          const para = $createParagraphNode();
+          for (const child of listItem.getChildren()) {
+            para.append(child);
+          }
+          const listChildren = list.getChildren();
+          const itemIndex = listItem.getIndexWithinParent();
+          const afterItems = listChildren.slice(itemIndex + 1);
+
+          if (listChildren.length === 1) {
+            list.replace(para);
+          } else if (itemIndex === 0) {
+            list.insertBefore(para);
+            listItem.remove();
+          } else if (afterItems.length === 0) {
+            list.insertAfter(para);
+            listItem.remove();
+          } else {
+            // Middle: split list — items after go to a new list
+            const newList = $createListNode(list.getListType());
+            for (const item of afterItems) {
+              item.remove();
+              newList.append(item);
+            }
+            list.insertAfter(newList);
+            list.insertAfter(para);
+            listItem.remove();
+          }
+          para.select();
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor]);
+  return null;
+}

--- a/src/editor/transformers.ts
+++ b/src/editor/transformers.ts
@@ -1,0 +1,8 @@
+import { CHECK_LIST, TRANSFORMERS } from "@lexical/markdown";
+
+// Support both "- [ ] " and "-[ ] " (with or without space between dash and bracket)
+export const CUSTOM_CHECK_LIST = {
+  ...CHECK_LIST,
+  regExp: /^(\s*)[-*+]\s?(\[(\s|x)?\])\s/i,
+};
+export const CUSTOM_TRANSFORMERS = [CUSTOM_CHECK_LIST, ...TRANSFORMERS];

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,35 @@
+import { $generateHtmlFromNodes } from "@lexical/html";
+import { $convertToMarkdownString } from "@lexical/markdown";
+import { invoke } from "@tauri-apps/api/core";
+import type { LexicalEditor } from "lexical";
+import { useCallback } from "react";
+import { CUSTOM_TRANSFORMERS } from "../editor/transformers";
+
+interface UseCopyToClipboardOptions {
+  editorMode: "rich" | "plain";
+  plainContent: string;
+  copyAsRichText: boolean;
+  editor?: LexicalEditor | null;
+}
+
+export function useCopyToClipboard({
+  editorMode,
+  plainContent,
+  copyAsRichText,
+  editor,
+}: UseCopyToClipboardOptions) {
+  const copyToClipboard = useCallback(() => {
+    if (editorMode === "plain") {
+      invoke("copy_to_clipboard", { content: plainContent });
+      return;
+    }
+    if (!editor) return;
+    editor.getEditorState().read(() => {
+      const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
+      const htmlContent = copyAsRichText ? $generateHtmlFromNodes(editor) : undefined;
+      invoke("copy_to_clipboard", { content, htmlContent });
+    });
+  }, [editorMode, plainContent, copyAsRichText, editor]);
+
+  return { copyToClipboard };
+}

--- a/src/hooks/useEditorDraftSync.ts
+++ b/src/hooks/useEditorDraftSync.ts
@@ -1,0 +1,91 @@
+import { $convertFromMarkdownString, $convertToMarkdownString } from "@lexical/markdown";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { EditorState } from "lexical";
+import { useCallback, useEffect, useRef } from "react";
+import { CUSTOM_TRANSFORMERS } from "../editor/transformers";
+
+interface UseEditorDraftSyncOptions {
+  editorMode: "rich" | "plain";
+  plainContent: string;
+  setPlainContent: (c: string) => void;
+  newDocTrigger: number;
+  onFocusPlain: () => void;
+}
+
+export function useEditorDraftSync({
+  editorMode,
+  plainContent,
+  setPlainContent,
+  newDocTrigger,
+  onFocusPlain,
+}: UseEditorDraftSyncOptions) {
+  const [editor] = useLexicalComposerContext();
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevEditorModeRef = useRef(editorMode);
+
+  const loadDraftForMode = useCallback(
+    (mode: "rich" | "plain") => {
+      invoke<string>("get_draft").then((content) => {
+        if (mode === "plain") {
+          setPlainContent(content ?? "");
+        } else {
+          editor.update(() => {
+            $convertFromMarkdownString(content ?? "", CUSTOM_TRANSFORMERS);
+          });
+        }
+      });
+    },
+    [editor, setPlainContent],
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally runs only on mount
+  useEffect(() => {
+    loadDraftForMode(editorMode);
+  }, []);
+
+  // Reload editor after new_document IPC clears the draft
+  useEffect(() => {
+    if (newDocTrigger === 0) return;
+    loadDraftForMode(editorMode);
+  }, [newDocTrigger, loadDraftForMode, editorMode]);
+
+  // Reload draft and auto-focus editor when the window is shown via global shortcut or tray
+  useEffect(() => {
+    const unlisten = listen("window-shown", () => {
+      loadDraftForMode(editorMode);
+      if (editorMode === "rich") {
+        editor.focus();
+      } else {
+        onFocusPlain();
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [editor, editorMode, loadDraftForMode, onFocusPlain]);
+
+  // Load plainContent into editor when switching plain → rich
+  useEffect(() => {
+    if (prevEditorModeRef.current === "plain" && editorMode === "rich") {
+      editor.update(() => {
+        $convertFromMarkdownString(plainContent, CUSTOM_TRANSFORMERS);
+      });
+    }
+    prevEditorModeRef.current = editorMode;
+  }, [editorMode, editor, plainContent]);
+
+  function handleChange(editorState: EditorState) {
+    if (editorMode === "plain") return;
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      editorState.read(() => {
+        const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
+        invoke("save_draft", { content });
+      });
+    }, 500);
+  }
+
+  return { loadDraftForMode, handleChange };
+}

--- a/src/hooks/useMenuEventListeners.ts
+++ b/src/hooks/useMenuEventListeners.ts
@@ -1,0 +1,205 @@
+import { $convertFromMarkdownString, $convertToMarkdownString } from "@lexical/markdown";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import {
+  $getSelection,
+  $insertNodes,
+  $isRangeSelection,
+  $parseSerializedNode,
+  createEditor,
+} from "lexical";
+import { useEffect } from "react";
+import { EDITOR_NODES } from "../editor/nodes";
+import { CUSTOM_TRANSFORMERS } from "../editor/transformers";
+import type { Settings } from "../types/settings";
+import { useCopyToClipboard } from "./useCopyToClipboard";
+
+interface UseMenuEventListenersOptions {
+  editorMode: "rich" | "plain";
+  plainContent: string;
+  copyAsRichText: boolean;
+  setCopyAsRichText: (v: boolean) => void;
+  setSendShortcut: (v: string) => void;
+  setIsHistoryOpen: (open: boolean) => void;
+  onToggleHistory: () => void;
+  onClearHistory: () => void;
+  onNew: () => void;
+  onPastePlainText: (text: string) => void;
+  handleModeToggle: () => void;
+  handleClearAll: () => void;
+}
+
+export function useMenuEventListeners({
+  editorMode,
+  plainContent,
+  copyAsRichText,
+  setCopyAsRichText,
+  setSendShortcut,
+  setIsHistoryOpen,
+  onToggleHistory,
+  onClearHistory,
+  onNew,
+  onPastePlainText,
+  handleModeToggle,
+  handleClearAll,
+}: UseMenuEventListenersOptions) {
+  const [editor] = useLexicalComposerContext();
+  const { copyToClipboard } = useCopyToClipboard({
+    editorMode,
+    plainContent,
+    copyAsRichText,
+    editor,
+  });
+
+  // Listen for menu bar "New Document" event
+  useEffect(() => {
+    const unlisten = listen("menu-new-document", () => {
+      onNew();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [onNew]);
+
+  // Listen for Edit > Clear All menu event
+  useEffect(() => {
+    const unlisten = listen("menu-clear-all", () => {
+      handleClearAll();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [handleClearAll]);
+
+  // Listen for menu bar "Export…" event
+  useEffect(() => {
+    const unlisten = listen("menu-export", () => {
+      if (editorMode === "plain") {
+        invoke("export_file", { content: plainContent, defaultName: "note.md" });
+      } else {
+        editor.getEditorState().read(() => {
+          const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
+          invoke("export_file", { content, defaultName: "note.md" });
+        });
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [editor, editorMode, plainContent]);
+
+  // Listen for menu bar "Send to Clipboard" event
+  useEffect(() => {
+    const unlisten = listen("menu-send-to-clipboard", () => {
+      copyToClipboard();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [copyToClipboard]);
+
+  // Listen for "Paste and Match Style" menu event
+  useEffect(() => {
+    const unlisten = listen("menu-paste-and-match-style", async () => {
+      const text = await invoke<string>("read_clipboard_text").catch(() => null);
+      if (text == null) return;
+      if (editorMode === "plain") {
+        onPastePlainText(text);
+      } else {
+        editor.update(() => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            selection.insertText(text);
+          }
+        });
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [editor, editorMode, onPastePlainText]);
+
+  // Listen for "Paste from Markdown" menu event
+  useEffect(() => {
+    const unlisten = listen("menu-paste-from-markdown", async () => {
+      const text = await invoke<string>("read_clipboard_text").catch(() => null);
+      if (!text) return;
+      if (editorMode === "plain") {
+        onPastePlainText(text);
+      } else {
+        const tempEditor = createEditor({ nodes: EDITOR_NODES });
+        await new Promise<void>((resolve) => {
+          tempEditor.update(
+            () => {
+              $convertFromMarkdownString(text, CUSTOM_TRANSFORMERS);
+            },
+            { onUpdate: resolve },
+          );
+        });
+        const { root } = tempEditor.getEditorState().toJSON();
+        const serializedNodes = root.children;
+        editor.update(() => {
+          $insertNodes(serializedNodes.map((json) => $parseSerializedNode(json)));
+        });
+      }
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [editor, editorMode, onPastePlainText]);
+
+  // Listen for "open-history-panel" event emitted by the tray menu (open-only)
+  useEffect(() => {
+    const unlisten = listen("open-history-panel", () => {
+      setIsHistoryOpen(true);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [setIsHistoryOpen]);
+
+  // Listen for menu bar View > History toggle event
+  useEffect(() => {
+    const unlisten = listen("menu-toggle-history", () => {
+      onToggleHistory();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [onToggleHistory]);
+
+  // Listen for menu bar View > Editor Mode submenu events (⌘⇧M via native menu)
+  useEffect(() => {
+    const unlisten = listen<string>("menu-set-editor-mode", (event) => {
+      const targetMode = event.payload as "rich" | "plain";
+      if (targetMode === editorMode) return;
+      handleModeToggle();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [handleModeToggle, editorMode]);
+
+  // Listen for View > Clear History… menu event
+  useEffect(() => {
+    const unlisten = listen("menu-clear-history", () => {
+      onClearHistory();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [onClearHistory]);
+
+  // Listen for settings-changed event emitted by the backend after save_settings
+  useEffect(() => {
+    const unlisten = listen<Settings>("settings-changed", (event) => {
+      setCopyAsRichText(event.payload.copy_as_rich_text ?? false);
+      setSendShortcut(event.payload.send_shortcut ?? "super+enter");
+      // editor_mode not handled here — managed via handleModeToggle / save_editor_mode
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [setCopyAsRichText, setSendShortcut]);
+}

--- a/src/utils/hotkey.ts
+++ b/src/utils/hotkey.ts
@@ -1,3 +1,20 @@
+export function matchesSendShortcut(
+  e: KeyboardEvent | React.KeyboardEvent,
+  shortcut: string,
+): boolean {
+  const parts = shortcut.toLowerCase().split("+");
+  const key = parts[parts.length - 1];
+  return (
+    e.ctrlKey === parts.includes("ctrl") &&
+    e.altKey === parts.includes("alt") &&
+    e.shiftKey === parts.includes("shift") &&
+    e.metaKey === parts.includes("super") &&
+    (e.key.toLowerCase() === key ||
+      e.code.toLowerCase() === key ||
+      codeToHotkeySegment(e.code) === key)
+  );
+}
+
 // Map a keyboard Code (e.g. "KeyM", "Space") to the hotkey segment (e.g. "m", "space")
 export function codeToHotkeySegment(code: string): string {
   if (code.startsWith("Key")) return code.slice(3).toLowerCase();


### PR DESCRIPTION
Closes #106

## Summary

- Split `MarkdownEditor.tsx` (1,048 lines → 532 lines) into focused modules
- Moved 5 Lexical plugin components to `src/editor/plugins/`
- Extracted `SendToClipboardButton` to `src/components/`
- Extracted shared constants (`CUSTOM_TRANSFORMERS`) to `src/editor/transformers.ts`
- Moved `matchesSendShortcut` helper to `src/utils/hotkey.ts`
- Created `src/hooks/useCopyToClipboard.ts` — centralizes clipboard copy logic (4 duplicated call sites → 1 hook)
- Created `src/hooks/useEditorDraftSync.ts` — encapsulates draft load/save and mode-switch effects
- Created `src/hooks/useMenuEventListeners.ts` — encapsulates all 11 menu event `listen()` registrations

## New file structure

```
src/
├── editor/
│   ├── plugins/
│   │   ├── CodeEnterPlugin.tsx
│   │   ├── CodeExitPlugin.tsx
│   │   ├── ListShiftTabExitPlugin.tsx
│   │   ├── InlineCodeFormatResetPlugin.tsx
│   │   └── InlineCodeEscapePlugin.tsx
│   ├── transformers.ts
│   └── MarkdownEditor.tsx  (532 lines, down from 1,048)
├── components/
│   └── SendToClipboardButton.tsx
└── hooks/
    ├── useCopyToClipboard.ts
    ├── useEditorDraftSync.ts
    └── useMenuEventListeners.ts
```

## Notes

- Pure structural refactor — no behavior changes
- `npm run check` and `npm run build` pass with zero errors

Part of #102