### PR TITLE
refactor(phase-a): share EditorMode type and extract composeFontFamily util

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,24 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import { MarkdownEditor } from "./editor/MarkdownEditor";
-import type { Settings } from "./types/settings";
-
-type EditorMode = "rich" | "plain";
-
-const RICH_FALLBACK_STACK = "Inter, Avenir, Helvetica, Arial, sans-serif";
-const PLAIN_FALLBACK_STACK =
-  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
-
-function composeFontFamily(
-  userFont: string | null | undefined,
-  appendFallback: boolean | undefined,
-  fallbackStack: string,
-): string | null {
-  const trimmed = userFont?.trim() ?? "";
-  if (!appendFallback) return trimmed || null;
-  if (trimmed) return `"${trimmed}", ${fallbackStack}`;
-  return fallbackStack;
-}
+import type { EditorMode, Settings } from "./types/settings";
+import { composeFontFamily, PLAIN_FALLBACK_STACK, RICH_FALLBACK_STACK } from "./utils/font";
 
 function App() {
   const [editorMode, setEditorMode] = useState<EditorMode>("rich");

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -25,6 +25,7 @@ import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { useEditorDraftSync } from "../hooks/useEditorDraftSync";
 import { useHistory } from "../hooks/useHistory";
 import { useMenuEventListeners } from "../hooks/useMenuEventListeners";
+import type { EditorMode } from "../types/settings";
 import { matchesSendShortcut } from "../utils/hotkey";
 import { EDITOR_NODES } from "./nodes";
 import { CodeEnterPlugin } from "./plugins/CodeEnterPlugin";
@@ -64,8 +65,8 @@ interface EditorPluginsProps {
   onPendingConsumed: () => void;
   newDocTrigger: number;
   onNew: () => void;
-  editorMode: "rich" | "plain";
-  onModeChange: (mode: "rich" | "plain") => void;
+  editorMode: EditorMode;
+  onModeChange: (mode: EditorMode) => void;
   plainContent: string;
   setPlainContent: (c: string) => void;
   modeToggleFnRef: React.MutableRefObject<(() => void) | null>;
@@ -267,8 +268,8 @@ function EditorPlugins({
 }
 
 interface MarkdownEditorProps {
-  editorMode: "rich" | "plain";
-  onModeChange: (mode: "rich" | "plain") => void;
+  editorMode: EditorMode;
+  onModeChange: (mode: EditorMode) => void;
   richFontFamily?: string | null;
   richFontSize?: number | null;
   plainFontFamily?: string | null;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,5 @@
+export type EditorMode = "rich" | "plain";
+
 export interface Settings {
   hotkey: string;
   launch_at_login: boolean;

--- a/src/utils/font.ts
+++ b/src/utils/font.ts
@@ -1,0 +1,14 @@
+export const RICH_FALLBACK_STACK = "Inter, Avenir, Helvetica, Arial, sans-serif";
+export const PLAIN_FALLBACK_STACK =
+  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
+
+export function composeFontFamily(
+  userFont: string | null | undefined,
+  appendFallback: boolean | undefined,
+  fallbackStack: string,
+): string | null {
+  const trimmed = userFont?.trim() ?? "";
+  if (!appendFallback) return trimmed || null;
+  if (trimmed) return `"${trimmed}", ${fallbackStack}`;
+  return fallbackStack;
+}


### PR DESCRIPTION
Part of the refactoring roadmap: #111
Closes #112

## Background

`EditorMode = "rich" | "plain"` was defined in `App.tsx` but duplicated as inline union literals in `MarkdownEditor.tsx`. Similarly, `composeFontFamily` and the fallback font stack constants were pure utilities living in `App.tsx` with no component dependencies.

## Summary

- Add `EditorMode` type to `src/types/settings.ts` and export it; import in `App.tsx` and `MarkdownEditor.tsx` (replaces 4 inline union literals)
- Move `composeFontFamily`, `RICH_FALLBACK_STACK`, and `PLAIN_FALLBACK_STACK` from `App.tsx` to new `src/utils/font.ts`

## Test plan

- [x] `npm run tauri dev`
- [x] Verify editor mode toggle (rich ↔ plain) still works
- [x] Verify font settings apply correctly in both modes
- [x] `npm run check` passes with no errors