### PR TITLE
refactor(phase-b): extract useMenuEvent helper hook

### DIFF
--- a/src/hooks/useMenuEvent.ts
+++ b/src/hooks/useMenuEvent.ts
@@ -1,0 +1,37 @@
+import { type EventCallback, type EventName, listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useEffect } from "react";
+
+/**
+ * Subscribes to a Tauri menu/event and automatically unlistens on cleanup.
+ *
+ * Re-subscribes whenever `deps` changes, matching the pattern:
+ *   useEffect(() => {
+ *     const unlisten = listen(event, handler);
+ *     return () => { unlisten.then(fn => fn()); };
+ *   }, deps);
+ *
+ * `handler` is intentionally excluded from the effect's dep array — callers
+ * control re-subscription exclusively through `deps`.
+ *
+ * @param event   - Tauri event name to listen for
+ * @param handler - Callback invoked with the event object on each emission
+ * @param deps    - Values that trigger re-subscription when changed (default: [])
+ */
+export function useMenuEvent<T = unknown>(
+  event: EventName,
+  handler: EventCallback<T>,
+  deps: React.DependencyList = [],
+): void {
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    listen<T>(event, handler).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+    // handler is intentionally omitted from deps; callers use `deps` to control
+    // re-subscription, mirroring the original per-effect pattern.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event, ...deps]);
+}

--- a/src/hooks/useMenuEvent.ts
+++ b/src/hooks/useMenuEvent.ts
@@ -22,6 +22,7 @@ export function useMenuEvent<T = unknown>(
   handler: EventCallback<T>,
   deps: React.DependencyList = [],
 ): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: handler is intentionally omitted; callers control re-subscription via `deps`
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;
     listen<T>(event, handler).then((fn) => {
@@ -30,8 +31,5 @@ export function useMenuEvent<T = unknown>(
     return () => {
       unlisten?.();
     };
-    // handler is intentionally omitted from deps; callers use `deps` to control
-    // re-subscription, mirroring the original per-effect pattern.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [event, ...deps]);
 }

--- a/src/hooks/useMenuEventListeners.ts
+++ b/src/hooks/useMenuEventListeners.ts
@@ -1,7 +1,6 @@
 import { $convertFromMarkdownString, $convertToMarkdownString } from "@lexical/markdown";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import {
   $getSelection,
   $insertNodes,
@@ -9,11 +8,11 @@ import {
   $parseSerializedNode,
   createEditor,
 } from "lexical";
-import { useEffect } from "react";
 import { EDITOR_NODES } from "../editor/nodes";
 import { CUSTOM_TRANSFORMERS } from "../editor/transformers";
 import type { Settings } from "../types/settings";
 import { useCopyToClipboard } from "./useCopyToClipboard";
+import { useMenuEvent } from "./useMenuEvent";
 
 interface UseMenuEventListenersOptions {
   editorMode: "rich" | "plain";
@@ -52,154 +51,84 @@ export function useMenuEventListeners({
     editor,
   });
 
-  // Listen for menu bar "New Document" event
-  useEffect(() => {
-    const unlisten = listen("menu-new-document", () => {
-      onNew();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [onNew]);
+  useMenuEvent("menu-new-document", onNew, [onNew]);
 
-  // Listen for Edit > Clear All menu event
-  useEffect(() => {
-    const unlisten = listen("menu-clear-all", () => {
-      handleClearAll();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [handleClearAll]);
+  useMenuEvent("menu-clear-all", handleClearAll, [handleClearAll]);
 
-  // Listen for menu bar "Export…" event
-  useEffect(() => {
-    const unlisten = listen("menu-export", () => {
-      if (editorMode === "plain") {
-        invoke("export_file", { content: plainContent, defaultName: "note.md" });
-      } else {
-        editor.getEditorState().read(() => {
-          const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
-          invoke("export_file", { content, defaultName: "note.md" });
-        });
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
+  useMenuEvent("menu-export", () => {
+    if (editorMode === "plain") {
+      invoke("export_file", { content: plainContent, defaultName: "note.md" });
+    } else {
+      editor.getEditorState().read(() => {
+        const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
+        invoke("export_file", { content, defaultName: "note.md" });
+      });
+    }
   }, [editor, editorMode, plainContent]);
 
-  // Listen for menu bar "Send to Clipboard" event
-  useEffect(() => {
-    const unlisten = listen("menu-send-to-clipboard", () => {
-      copyToClipboard();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [copyToClipboard]);
+  useMenuEvent("menu-send-to-clipboard", copyToClipboard, [copyToClipboard]);
 
-  // Listen for "Paste and Match Style" menu event
-  useEffect(() => {
-    const unlisten = listen("menu-paste-and-match-style", async () => {
-      const text = await invoke<string>("read_clipboard_text").catch(() => null);
-      if (text == null) return;
-      if (editorMode === "plain") {
-        onPastePlainText(text);
-      } else {
-        editor.update(() => {
-          const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            selection.insertText(text);
-          }
-        });
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
+  useMenuEvent("menu-paste-and-match-style", async () => {
+    const text = await invoke<string>("read_clipboard_text").catch(() => null);
+    if (text == null) return;
+    if (editorMode === "plain") {
+      onPastePlainText(text);
+    } else {
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText(text);
+        }
+      });
+    }
   }, [editor, editorMode, onPastePlainText]);
 
-  // Listen for "Paste from Markdown" menu event
-  useEffect(() => {
-    const unlisten = listen("menu-paste-from-markdown", async () => {
-      const text = await invoke<string>("read_clipboard_text").catch(() => null);
-      if (!text) return;
-      if (editorMode === "plain") {
-        onPastePlainText(text);
-      } else {
-        const tempEditor = createEditor({ nodes: EDITOR_NODES });
-        await new Promise<void>((resolve) => {
-          tempEditor.update(
-            () => {
-              $convertFromMarkdownString(text, CUSTOM_TRANSFORMERS);
-            },
-            { onUpdate: resolve },
-          );
-        });
-        const { root } = tempEditor.getEditorState().toJSON();
-        const serializedNodes = root.children;
-        editor.update(() => {
-          $insertNodes(serializedNodes.map((json) => $parseSerializedNode(json)));
-        });
-      }
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
+  useMenuEvent("menu-paste-from-markdown", async () => {
+    const text = await invoke<string>("read_clipboard_text").catch(() => null);
+    if (!text) return;
+    if (editorMode === "plain") {
+      onPastePlainText(text);
+    } else {
+      const tempEditor = createEditor({ nodes: EDITOR_NODES });
+      await new Promise<void>((resolve) => {
+        tempEditor.update(
+          () => {
+            $convertFromMarkdownString(text, CUSTOM_TRANSFORMERS);
+          },
+          { onUpdate: resolve },
+        );
+      });
+      const { root } = tempEditor.getEditorState().toJSON();
+      const serializedNodes = root.children;
+      editor.update(() => {
+        $insertNodes(serializedNodes.map((json) => $parseSerializedNode(json)));
+      });
+    }
   }, [editor, editorMode, onPastePlainText]);
 
-  // Listen for "open-history-panel" event emitted by the tray menu (open-only)
-  useEffect(() => {
-    const unlisten = listen("open-history-panel", () => {
-      setIsHistoryOpen(true);
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [setIsHistoryOpen]);
+  useMenuEvent("open-history-panel", () => setIsHistoryOpen(true), [setIsHistoryOpen]);
 
-  // Listen for menu bar View > History toggle event
-  useEffect(() => {
-    const unlisten = listen("menu-toggle-history", () => {
-      onToggleHistory();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [onToggleHistory]);
+  useMenuEvent("menu-toggle-history", onToggleHistory, [onToggleHistory]);
 
-  // Listen for menu bar View > Editor Mode submenu events (⌘⇧M via native menu)
-  useEffect(() => {
-    const unlisten = listen<string>("menu-set-editor-mode", (event) => {
+  useMenuEvent<string>(
+    "menu-set-editor-mode",
+    (event) => {
       const targetMode = event.payload as "rich" | "plain";
       if (targetMode === editorMode) return;
       handleModeToggle();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [handleModeToggle, editorMode]);
+    },
+    [handleModeToggle, editorMode],
+  );
 
-  // Listen for View > Clear History… menu event
-  useEffect(() => {
-    const unlisten = listen("menu-clear-history", () => {
-      onClearHistory();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [onClearHistory]);
+  useMenuEvent("menu-clear-history", onClearHistory, [onClearHistory]);
 
-  // Listen for settings-changed event emitted by the backend after save_settings
-  useEffect(() => {
-    const unlisten = listen<Settings>("settings-changed", (event) => {
+  useMenuEvent<Settings>(
+    "settings-changed",
+    (event) => {
       setCopyAsRichText(event.payload.copy_as_rich_text ?? false);
       setSendShortcut(event.payload.send_shortcut ?? "super+enter");
       // editor_mode not handled here — managed via handleModeToggle / save_editor_mode
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [setCopyAsRichText, setSendShortcut]);
+    },
+    [setCopyAsRichText, setSendShortcut],
+  );
 }


### PR DESCRIPTION
Closes #113

Part of the refactoring roadmap: #111

## Background

`src/hooks/useMenuEventListeners.ts` contained 11 `useEffect` hooks, each duplicating the same `listen` / `unlisten` teardown pattern:

```ts
useEffect(() => {
  const unlisten = listen("some-event", (e) => { ... });
  return () => { unlisten.then(fn => fn()); };
}, [...]);
```

## Summary

- Add `src/hooks/useMenuEvent.ts` — a `useMenuEvent<T>(event, handler, deps?)` helper hook that encapsulates the `listen` / `unlisten` teardown pattern
- Refactor `useMenuEventListeners.ts` to replace all 11 `useEffect` blocks with single `useMenuEvent` calls (205 lines → 134 lines)

## Test plan

- [ ] `npm run tauri dev`
- [ ] File > New Document menu item works
- [ ] Edit > Clear All menu item works
- [ ] File > Export… menu item works
- [ ] Copy & Close (Send to Clipboard) works
- [ ] Edit > Paste and Match Style works
- [ ] Edit > Paste from Markdown works
- [ ] History panel opens from tray menu
- [ ] View > History toggle works
- [ ] View > Editor Mode switch works
- [ ] View > Clear History… works
- [ ] Settings changes apply (copy format, send shortcut)