### PR TITLE
fix: resolve clippy warnings and improve npm scripts for Rust tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
 
       - name: Lint
-        run: npm run check:ci
+        run: npm run check:ci:js
 
       - name: Build
         run: npm run build
@@ -30,11 +30,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm ci
+
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
       - name: Check
-        run: cargo check --manifest-path src-tauri/Cargo.toml
+        run: npm run check:rust

--- a/package.json
+++ b/package.json
@@ -9,9 +9,14 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "gen-icons": "bash scripts/gen-icons.sh",
-    "lint": "biome check --write src/ vite.config.ts",
-    "check": "biome check src/ vite.config.ts",
-    "check:ci": "biome check --reporter=github src/ vite.config.ts"
+    "check:js": "biome check src/ vite.config.ts",
+    "fix:js": "biome check --write src/ vite.config.ts",
+    "check:rust": "cargo fmt --check --manifest-path src-tauri/Cargo.toml && cargo clippy --manifest-path src-tauri/Cargo.toml",
+    "fix:rust": "cargo fmt --manifest-path src-tauri/Cargo.toml && cargo clippy --fix --allow-dirty --manifest-path src-tauri/Cargo.toml",
+    "check": "npm run check:js && npm run check:rust",
+    "fix": "npm run fix:js && npm run fix:rust",
+    "check:ci:js": "biome check --reporter=github src/ vite.config.ts",
+    "check:ci": "npm run check:ci:js && npm run check:rust"
   },
   "dependencies": {
     "@lexical/code": "^0.42.0",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -229,7 +229,7 @@ pub fn re_register_shortcut(app: &AppHandle, hotkey: &str) -> Result<(), String>
     }
 
     app.global_shortcut()
-        .on_shortcut(shortcut.clone(), move |app, _shortcut, event| {
+        .on_shortcut(shortcut, move |app, _shortcut, event| {
             if event.state == KeyPressState::Pressed {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.show();
@@ -325,7 +325,7 @@ fn save_history_entry(app: &AppHandle, content: &str) -> Result<(), String> {
     let title_preview = extract_title_preview(content);
 
     let history = history_dir(app)?;
-    fs::write(&history_file_path(&history, &id), content).map_err(|e| e.to_string())?;
+    fs::write(history_file_path(&history, &id), content).map_err(|e| e.to_string())?;
 
     let index_path = history.join("index.json");
     let mut entries = load_history_entries(app).unwrap_or_default();


### PR DESCRIPTION
## Background

`cargo clippy` reported two warnings in `commands.rs`:

- `clone_on_copy`: `Shortcut` implements `Copy`, so `.clone()` was unnecessary
- `needless_borrows_for_generic_args`: `&` before `history_file_path(...)` in `fs::write` was redundant

Additionally, there were no npm scripts to run `cargo check`, `cargo clippy`, or `cargo fmt` from the project root, making it inconvenient to run a unified check across both the frontend and Rust codebase in CI.

## Summary

- Fix `clone_on_copy` and `needless_borrows_for_generic_args` clippy warnings in `src-tauri/src/commands.rs`
- Restructure frontend npm scripts: `lint`/`check`/`check:ci` → `fix:js`/`check:js`/`check:ci:js`
- Add `check:rust` (`cargo fmt --check` + `cargo clippy`) and `fix:rust` (`cargo fmt` + `cargo clippy --fix`)
- Add unified `check` (`check:js` + `check:rust`), `fix` (`fix:js` + `fix:rust`), and `check:ci` (`check:ci:js` + `check:rust`) scripts

## Test plan

- [ ] `npm run check` passes with no warnings or errors
- [ ] `npm run check:ci` passes (Biome github reporter + clippy)
- [ ] `npm run fix:rust` applies `cargo fmt` and `cargo clippy --fix` cleanly