### PR TITLE
chore: format Rust code with cargo fmt and clippy --fix

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,12 +3,12 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use tauri::{AppHandle, Emitter, Manager};
 use tauri::menu::{CheckMenuItem, MenuItem};
+use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_clipboard_manager::ClipboardExt;
-use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_dialog::{DialogExt, FilePath};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState as KeyPressState};
+use tauri_plugin_notification::NotificationExt;
 
 // ---------------------------------------------------------------------------
 // App state: tracks the currently registered global shortcut and menu items
@@ -143,10 +143,7 @@ fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
 }
 
 fn extract_title_preview(content: &str) -> String {
-    let first_line = content
-        .lines()
-        .find(|l| !l.trim().is_empty())
-        .unwrap_or("");
+    let first_line = content.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
     // Strip leading Markdown heading markers
     let stripped = first_line.trim_start_matches('#').trim();
     if stripped.is_empty() {
@@ -220,10 +217,7 @@ pub fn re_register_shortcut(app: &AppHandle, hotkey: &str) -> Result<(), String>
         .map_err(|e| format!("Invalid hotkey '{hotkey}': {e}"))?;
 
     let state = app.state::<AppState>();
-    let mut sc = state
-        .shortcut
-        .lock()
-        .expect("mutex poisoned: shortcut");
+    let mut sc = state.shortcut.lock().expect("mutex poisoned: shortcut");
     if let Some(old) = sc.shortcut.take() {
         let _ = app.global_shortcut().unregister(old);
     }
@@ -293,12 +287,8 @@ pub fn save_settings(app: AppHandle, mut settings: Settings) -> Result<(), Strin
 
 #[tauri::command]
 pub fn list_fonts() -> Result<Vec<String>, String> {
-    let collection = font_enumeration::Collection::new()
-        .map_err(|e| e.to_string())?;
-    let mut families: Vec<String> = collection
-        .all()
-        .map(|f| f.family_name.clone())
-        .collect();
+    let collection = font_enumeration::Collection::new().map_err(|e| e.to_string())?;
+    let mut families: Vec<String> = collection.all().map(|f| f.family_name.clone()).collect();
     families.sort_unstable();
     families.dedup();
     Ok(families)
@@ -414,7 +404,8 @@ pub fn copy_to_clipboard(
     // 6. Notify user (best-effort; silently ignored if permission denied or DND)
     let settings = load_settings_from_disk(&app).unwrap_or_default();
     if settings.notify_on_copy {
-        let _ = app.notification()
+        let _ = app
+            .notification()
             .builder()
             .title("Popmark")
             .body("Copied to clipboard")
@@ -565,10 +556,7 @@ pub fn set_history_panel_open(state: tauri::State<'_, AppState>, open: bool) {
 pub fn show_settings_window(app: AppHandle) -> Result<(), String> {
     // Unregister global shortcut while settings window is open
     let state = app.state::<AppState>();
-    let mut sc = state
-        .shortcut
-        .lock()
-        .expect("mutex poisoned: shortcut");
+    let mut sc = state.shortcut.lock().expect("mutex poisoned: shortcut");
     if let Some(old) = sc.shortcut.take() {
         let _ = app.global_shortcut().unregister(old);
     }
@@ -606,10 +594,7 @@ pub fn set_hotkey_capture_active(app: AppHandle, active: bool) -> Result<(), Str
     let state = app.state::<AppState>();
     if active {
         // Unregister while user is capturing a new hotkey
-        let mut sc = state
-            .shortcut
-            .lock()
-            .expect("mutex poisoned: shortcut");
+        let mut sc = state.shortcut.lock().expect("mutex poisoned: shortcut");
         if let Some(old) = sc.shortcut.take() {
             let _ = app.global_shortcut().unregister(old);
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,13 +167,8 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         true,
         Some("cmd+n"),
     )?;
-    let menu_export_item = MenuItem::with_id(
-        app,
-        "menu-export",
-        "Export\u{2026}",
-        true,
-        Some("cmd+s"),
-    )?;
+    let menu_export_item =
+        MenuItem::with_id(app, "menu-export", "Export\u{2026}", true, Some("cmd+s"))?;
     let menu_show_history_folder_item = MenuItem::with_id(
         app,
         "menu-show-history-folder",
@@ -195,13 +190,7 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         true,
         None::<&str>,
     )?;
-    let menu_help_item = MenuItem::with_id(
-        app,
-        "menu-help",
-        "Popmark Help",
-        true,
-        Some("cmd+?"),
-    )?;
+    let menu_help_item = MenuItem::with_id(app, "menu-help", "Popmark Help", true, Some("cmd+?"))?;
     let menu_paste_and_match_style_item = MenuItem::with_id(
         app,
         "menu-paste-and-match-style",
@@ -216,15 +205,9 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         true,
         None::<&str>,
     )?;
-    let menu_recall_last_item = MenuItem::with_id(
-        app,
-        "menu-recall-last",
-        "Recall Last",
-        false,
-        Some("cmd+r"),
-    )?;
-    app
-        .state::<AppState>()
+    let menu_recall_last_item =
+        MenuItem::with_id(app, "menu-recall-last", "Recall Last", false, Some("cmd+r"))?;
+    app.state::<AppState>()
         .menu
         .lock()
         .expect("mutex poisoned: menu")
@@ -305,12 +288,7 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                     &menu_move_to_center_item,
                 ],
             )?,
-            &Submenu::with_items(
-                app,
-                "Help",
-                true,
-                &[&menu_help_item],
-            )?,
+            &Submenu::with_items(app, "Help", true, &[&menu_help_item])?,
         ],
     )?;
     app.set_menu(menu)?;
@@ -353,8 +331,7 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                     let x = work_area.position.x
                         + (work_area.size.width as i32 - window_size.width as i32) / 2;
                     let y = work_area.position.y
-                        + (work_area.size.height as i32 - window_size.height as i32)
-                            / 2;
+                        + (work_area.size.height as i32 - window_size.height as i32) / 2;
                     let _ = window.set_position(PhysicalPosition::new(x, y));
                 }
             }
@@ -411,14 +388,12 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
-    let show_item =
-        MenuItem::with_id(app, "show-editor", "Show Editor", true, None::<&str>)?;
+    let show_item = MenuItem::with_id(app, "show-editor", "Show Editor", true, None::<&str>)?;
     let history_item =
         MenuItem::with_id(app, "open-history", "History\u{2026}", true, None::<&str>)?;
     let settings_item =
         MenuItem::with_id(app, "open-settings", "Settings\u{2026}", true, None::<&str>)?;
-    let quit_item =
-        MenuItem::with_id(app, "quit-popmark", "Quit Popmark", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, "quit-popmark", "Quit Popmark", true, None::<&str>)?;
     let tray_menu = Menu::with_items(
         app,
         &[
@@ -429,24 +404,25 @@ fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             &quit_item,
         ],
     )?;
-    let mut builder = TrayIconBuilder::new()
-        .menu(&tray_menu)
-        .on_menu_event(|app, event| match event.id().as_ref() {
-            "show-editor" => {
-                show_and_focus_main_window(app);
-            }
-            "open-history" => {
-                show_and_focus_main_window(app);
-                emit_to_main_window(app, "open-history-panel", ());
-            }
-            "open-settings" => {
-                let _ = commands::show_settings_window(app.clone());
-            }
-            "quit-popmark" => {
-                app.exit(0);
-            }
-            _ => {}
-        });
+    let mut builder =
+        TrayIconBuilder::new()
+            .menu(&tray_menu)
+            .on_menu_event(|app, event| match event.id().as_ref() {
+                "show-editor" => {
+                    show_and_focus_main_window(app);
+                }
+                "open-history" => {
+                    show_and_focus_main_window(app);
+                    emit_to_main_window(app, "open-history-panel", ());
+                }
+                "open-settings" => {
+                    let _ = commands::show_settings_window(app.clone());
+                }
+                "quit-popmark" => {
+                    app.exit(0);
+                }
+                _ => {}
+            });
     #[cfg(target_os = "macos")]
     {
         const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon.png");


### PR DESCRIPTION
## Summary

- Run `npm run fix:rust` (`cargo fmt` + `cargo clippy --fix`) to bring Rust source files into conformance with project formatting rules
- No behavioral changes — formatting only

## Files changed

- `src-tauri/src/commands.rs`
- `src-tauri/src/lib.rs`

## Test plan

- [x] `npm run check` passes without errors