### PR TITLE
ci: add GitHub Actions release pipeline

### DIFF
--- a/.github/homebrew/popmark.rb.mustache
+++ b/.github/homebrew/popmark.rb.mustache
@@ -1,0 +1,16 @@
+cask "popmark" do
+  version "{{version}}"
+  sha256 "{{artifacts.default.sha256}}"
+
+  url "{{artifacts.default.url}}"
+  name "Popmark"
+  desc "Markdown scratch-pad with global hotkey"
+  homepage "https://github.com/dayflower/popmark"
+
+  app "Popmark.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.eula.dayflower.popmark",
+    "~/Library/Preferences/com.eula.dayflower.popmark.plist",
+  ]
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Build Tauri app (ad-hoc signing)
         env:
           APPLE_SIGNING_IDENTITY: "-"
-        run: npm run tauri build
+        run: |
+          npm run tauri build -- --no-bundle
+          npm run tauri bundle -- --bundles app,dmg
 
       - name: Archive App Bundle as zip
         run: |
@@ -85,10 +87,10 @@ jobs:
         uses: dayflower/brew-up@v0.1.1
         with:
           release-tag: ${{ github.ref_name }}
-          template-path: .github/homebrew/popmark.rb.mustache
+          template-path: homebrew/popmark.rb.tmpl
           output-path: Casks/popmark.rb
           asset-map: |
-            default=Popmark_{{version}}_*.dmg
+            default=popmark-{{version}}-macos.zip
           target-repo: dayflower/homebrew-tap
           target-branch: main
           target-repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  check-version:
+    name: Check version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify versions match tag
+        run: |
+          TAG_VER="${GITHUB_REF_NAME#v}"
+
+          PKG_VER=$(jq -r .version package.json)
+          CARGO_VER=$(grep '^version' src-tauri/Cargo.toml | head -1 | cut -d'"' -f2)
+          TAURI_VER=$(jq -r .version src-tauri/tauri.conf.json)
+
+          FAILED=0
+          if [ "$PKG_VER" != "$TAG_VER" ]; then
+            echo "::error::package.json version ($PKG_VER) does not match tag ($TAG_VER)"
+            FAILED=1
+          fi
+          if [ "$CARGO_VER" != "$TAG_VER" ]; then
+            echo "::error::Cargo.toml version ($CARGO_VER) does not match tag ($TAG_VER)"
+            FAILED=1
+          fi
+          if [ "$TAURI_VER" != "$TAG_VER" ]; then
+            echo "::error::tauri.conf.json version ($TAURI_VER) does not match tag ($TAG_VER)"
+            FAILED=1
+          fi
+
+          if [ "$FAILED" -eq 1 ]; then
+            exit 1
+          fi
+
+          echo "All versions match tag: $TAG_VER"
+
+  build-and-release:
+    name: Build and release
+    runs-on: macos-latest
+    needs: check-version
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Tauri app (ad-hoc signing)
+        env:
+          APPLE_SIGNING_IDENTITY: "-"
+        run: npm run tauri build
+
+      - name: Archive App Bundle as zip
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd src-tauri/target/release/bundle/macos
+          zip -r "$GITHUB_WORKSPACE/popmark-${VERSION}-macos.zip" Popmark.app
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2.6.1
+        with:
+          files: |
+            popmark-*-macos.zip
+            src-tauri/target/release/bundle/dmg/*.dmg
+
+      - name: Update Homebrew tap
+        uses: dayflower/brew-up@v0.1.1
+        with:
+          release-tag: ${{ github.ref_name }}
+          template-path: .github/homebrew/popmark.rb.mustache
+          output-path: Casks/popmark.rb
+          asset-map: |
+            default=Popmark_{{version}}_*.dmg
+          target-repo: dayflower/homebrew-tap
+          target-branch: main
+          target-repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          publish-mode: pr

--- a/homebrew/popmark.rb.tmpl
+++ b/homebrew/popmark.rb.tmpl
@@ -9,6 +9,12 @@ cask "popmark" do
 
   app "Popmark.app"
 
+  caveats <<~EOS
+    This application is signed with ad-hoc signature.
+    You need to run 'xattr -dr com.apple.quarantine Popmark.app'
+    after installation to open it."
+  EOS
+
   zap trash: [
     "~/Library/Application Support/com.eula.dayflower.popmark",
     "~/Library/Preferences/com.eula.dayflower.popmark.plist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Popmark",
   "version": "0.1.0",
-  "identifier": "com.dayflower.popmark",
+  "identifier": "com.eula.dayflower.popmark",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
@@ -37,6 +37,8 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "category": "Productivity",
+    "copyright": "Copyright © 2026 dayflower",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Closes #7

## Background

Issue #7 defines the release pipeline goal: pushing a `vX.Y.Z` tag should automatically verify version consistency, build the macOS app with ad-hoc signing, publish it to GitHub Releases, and open a PR to update the Homebrew cask.

This PR implements that pipeline without notarization (no paid Apple Developer ID required).

## Summary

- Update `src-tauri/tauri.conf.json`: fix `identifier` to `com.eula.dayflower.popmark`, add `category` and `copyright` fields
- Add `homebrew/popmark.rb.tmpl`: Mustache template for the Homebrew cask, including a `caveats` block explaining the ad-hoc quarantine workaround
- Add `.github/workflows/release.yml`: release workflow triggered on `vX.Y.Z` tags
  - `check-version` job: verifies tag version matches `package.json`, `Cargo.toml`, and `tauri.conf.json`
  - `build-and-release` job: builds with `tauri build -- --no-bundle` then `tauri bundle -- --bundles app,dmg`, archives the `.app` as a `.zip`, publishes to GitHub Releases, and opens a Homebrew tap PR via `dayflower/brew-up`

## Test plan

- [ ] Push a `vX.Y.Z` tag whose version matches all three manifests → workflow passes version check, GitHub Release is created with `.zip` and `.dmg`, Homebrew tap PR is opened
- [ ] Push a `vX.Y.Z` tag whose version mismatches at least one manifest → `check-version` job fails with a clear error message
- [ ] Verify the Homebrew cask PR in `dayflower/homebrew-tap` has correct `url`, `sha256`, and `version` fields

## Notes

- `HOMEBREW_GITHUB_API_TOKEN` secret (fine-grained PAT with Contents + Pull requests read/write on `dayflower/homebrew-tap`) must be added to repo settings before the first release.