### PR TITLE
fix: pass GITHUB_TOKEN env var to brew-up action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
 
       - name: Update Homebrew tap
         uses: dayflower/brew-up@v0.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release-tag: ${{ github.ref_name }}
           template-path: homebrew/popmark.rb.tmpl


### PR DESCRIPTION
## Summary

- `brew-up` action requires `GITHUB_TOKEN` as an environment variable to fetch release asset metadata (SHA256 checksums etc.) from the GitHub API
- The "Update Homebrew tap" step was missing this env var, causing failures during Homebrew tap updates

## Changes

- Added `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `brew-up` step in `.github/workflows/release.yml`