### PR TITLE
chore: bump version to v0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tauri-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tauri-app",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@lexical/code": "^0.42.0",
         "@lexical/history": "^0.42.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-app",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "popmark"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "font-enumeration",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "popmark"
-version = "0.1.1"
+version = "0.1.2"
 description = "A popup Markdown editor triggered by a global shortcut"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Popmark",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.eula.dayflower.popmark",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Version bump: v0.1.2

Automated version bump via `scripts/bump-version.sh patch`.

### Changed files
- `package.json`
- `package-lock.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock`
- `src-tauri/tauri.conf.json`

### Next step

After this PR is merged, create and push the release tag:

```sh
git checkout main && git pull
git tag v0.1.2
git push origin v0.1.2
```