### PR TITLE
ci: trigger Homebrew tap update via release published event

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,27 @@
+name: Update Homebrew tap
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-homebrew-tap:
+    name: Update Homebrew tap
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Homebrew tap
+        uses: dayflower/brew-up@v0.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release-tag: ${{ github.ref_name }}
+          template-path: homebrew/popmark.rb.tmpl
+          output-path: Casks/popmark.rb
+          asset-map: |
+            default=popmark-{{version}}-macos.zip
+          target-repo: dayflower/homebrew-tap
+          target-branch: main
+          target-repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          publish-mode: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,18 +82,3 @@ jobs:
           files: |
             popmark-*-macos.zip
             src-tauri/target/release/bundle/dmg/*.dmg
-
-      - name: Update Homebrew tap
-        uses: dayflower/brew-up@v0.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          release-tag: ${{ github.ref_name }}
-          template-path: homebrew/popmark.rb.tmpl
-          output-path: Casks/popmark.rb
-          asset-map: |
-            default=popmark-{{version}}-macos.zip
-          target-repo: dayflower/homebrew-tap
-          target-branch: main
-          target-repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          publish-mode: pr


### PR DESCRIPTION
## Summary

- Remove `Update Homebrew tap` step from `release.yml`
- Add new workflow `homebrew-tap.yml` triggered by `release: published` event

## Motivation

Previously, the Homebrew tap update ran immediately after publishing the GitHub Release in the same job. This caused 404 errors because release assets were not yet available via GitHub's CDN at the time `brew-up` tried to download them.

By using the `release: published` event trigger, the new workflow only starts after GitHub has fully published the release and its assets, eliminating the race condition.

## Test plan

- [ ] Push a version tag and confirm `release.yml` completes (build + GitHub Release creation only)
- [ ] Confirm `homebrew-tap.yml` is triggered automatically by the published release event
- [ ] Confirm a PR is created in `dayflower/homebrew-tap` without 404 errors