### PR TITLE
fix: use merge commit instead of squash in bump-version.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -97,7 +97,7 @@ EOF
 echo "PR created: $PR_URL"
 
 # Enable auto-merge (squash) — requires auto-merge to be enabled in repo settings
-gh pr merge --auto --squash "$PR_URL"
+gh pr merge --auto --merge "$PR_URL"
 
 echo ""
 echo "Done! Auto-merge enabled on $PR_URL"


### PR DESCRIPTION
## Summary

- Change `gh pr merge --auto --squash` to `gh pr merge --auto --merge` in `scripts/bump-version.sh`
- Release branch commits are preserved in history instead of being squashed into one