### PR TITLE
ci: use PAT for GitHub Release to trigger downstream workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,10 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2.6.1
         with:
+          # Use a PAT instead of GITHUB_TOKEN so that the release event triggers
+          # other workflows (e.g. homebrew-tap). Events fired by GITHUB_TOKEN do
+          # not trigger subsequent workflow runs by design.
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           files: |
             popmark-*-macos.zip
             src-tauri/target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
## Summary

- Add `token: ${{ secrets.RELEASE_GITHUB_TOKEN }}` to the `action-gh-release` step in `release.yml`
- Events fired by `GITHUB_TOKEN` do not trigger subsequent workflow runs by design, so the `homebrew-tap` workflow was never kicked after a release was published
- Using a PAT instead causes the release event to propagate normally and trigger `homebrew-tap.yml`

## Setup required

Add a fine-grained PAT as a repository secret named `RELEASE_GITHUB_TOKEN`:

- Repository access: `dayflower/popmark`
- Permissions: **Contents: Read and write**