### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - uses: swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -9,10 +9,10 @@ jobs:
     name: Update Homebrew tap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Update Homebrew tap
-        uses: dayflower/brew-up@v0.1.1
+        uses: dayflower/brew-up@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check version consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify versions match tag
         run: |
@@ -47,9 +47,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: npm
@@ -77,7 +77,7 @@ jobs:
           zip -r "$GITHUB_WORKSPACE/popmark-${VERSION}-macos.zip" Popmark.app
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2.6.1
+        uses: softprops/action-gh-release@v3
         with:
           # Use a PAT instead of GITHUB_TOKEN so that the release event triggers
           # other workflows (e.g. homebrew-tap). Events fired by GITHUB_TOKEN do


### PR DESCRIPTION
## Summary

- `actions/checkout`: `v4` → `v6` (release.yml, homebrew-tap.yml)
- `actions/setup-node`: `v4` → `v6` (release.yml)
- `softprops/action-gh-release`: `v2.6.1` → `v3` (Node 20 → Node 24 runtime)
- `dayflower/brew-up`: `v0.1.1` → `v0` (floating tag)
- `swatinem/rust-cache`: fix casing `swatinem/` → `Swatinem/` (ci.yml)