### PR TITLE
ci: switch from dtolnay/rust-toolchain to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,9 @@ jobs:
 
       - run: npm ci
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
 
       - name: Check
         run: npm run check:rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,7 @@ jobs:
           node-version: lts/*
           cache: npm
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- Replace `dtolnay/rust-toolchain` with `actions-rust-lang/setup-rust-toolchain@v1` in CI and release workflows
- Remove `Swatinem/rust-cache` since the new action includes built-in caching
- Gain Problem Matchers for cargo/clippy/rustfmt error reporting in GitHub UI

## Notes

The new action sets `RUSTFLAGS=-D warnings` by default. Verified that the current codebase produces zero warnings under this flag (`cargo check` and `cargo clippy` both pass cleanly).

## Test plan

- [ ] CI workflow passes on this PR