### PR TITLE
chore: update GitHub Actions in pinact workflows to latest

### DIFF
--- a/.github/workflows/pinact-dispatch.yml
+++ b/.github/workflows/pinact-dispatch.yml
@@ -10,13 +10,13 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}
           private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -26,7 +26,7 @@ jobs:
           app_private_key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
           skip_push: "true"
 
-      - uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: chore/pinact

--- a/.github/workflows/pinact-pr.yml
+++ b/.github/workflows/pinact-pr.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token`: v1.12.0 → v3.1.1
- `actions/checkout`: v4.3.1 → v6.0.2
- `peter-evans/create-pull-request`: v7.0.11 → v8.1.1
- `suzuki-shunsuke/pinact-action`: v2.0.0 (no change — already latest)

All major version bumps are Node runtime upgrades (Node 16/20 → Node 24) with no input/output API changes.