### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -8,6 +8,8 @@ jobs:
   update-homebrew-tap:
     name: Update Homebrew tap
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   check-version:
     name: Check version consistency
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

Fixes CodeQL warnings: "Workflow does not contain permissions".

- `ci.yml`: Add workflow-level `permissions: contents: read` (both jobs are read-only)
- `homebrew-tap.yml`: Add `permissions: contents: read` to `update-homebrew-tap` job
- `release.yml`: Add `permissions: contents: read` to `check-version` job (the `build-and-release` job already had `contents: write`)

## Motivation

Without explicit `permissions` blocks, `GITHUB_TOKEN` defaults to broad write access. Specifying the minimum required permissions follows the principle of least privilege and satisfies CodeQL's security check.