### PR TITLE
feat: show syntax markers for inline formatting and headings in rich editor

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -22,6 +22,7 @@ Popmark is an application with a tray icon and standard menu bar, providing a qu
   - **Plain text mode**: displays the raw Markdown source in a monospaced textarea; no visual formatting is applied.
 - The selected mode is persisted and restored on next launch.
 - Supported Markdown elements: headings H1–H6, bold, italic, bold+italic, strikethrough, inline code, fenced code blocks (with optional language tag), blockquotes, unordered and ordered lists, checkbox (task) lists, horizontal rules, and links.
+- Inline syntax markers remain visible in the editor for inline code (`` ` ``), bold (`**`), italic (`*`), bold+italic (`***`), and strikethrough (`~~`), rendered in a dimmed, smaller style alongside the formatted text. These markers are CSS-only and do not appear in the clipboard output.
 - Checkbox lists use `- [ ]` (unchecked) and `- [x]` (checked) syntax.
 - Standard Markdown syntax is used (`#` for H1, `##` for H2, etc.).
 - Pressing Enter on a blank list item exits list mode and returns to normal paragraph mode.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -63,6 +63,8 @@ Popmark is not a file manager or a notes app. It is a fast scratch pad optimized
 The editor supports two modes, toggled via the toolbar button (**⌘⇧R** for Rich, **⌘⇧P** for Plain):
 
 - **Rich mode** (default): **source-visible WYSIWYG** (Obsidian style) — Markdown syntax markers (`#`, `**`, `` ` ``, etc.) remain visible in the editor while visual styling is applied at the same time (font size, weight, color, etc.). The user can edit the raw markers directly, and the styling updates live.
+
+Inline syntax markers for bold (`**`), italic (`*`), bold+italic (`***`), and strikethrough (`~~`) are rendered as CSS pseudo-elements (`::before` / `::after`) in a dimmed, slightly smaller style. This is purely visual: the markers are not part of the DOM text content and do not appear in clipboard output.
 - **Plain text mode**: a plain `<textarea>` displays the raw Markdown source. `spellCheck` is disabled and all Lexical formatting plugins are inactive.
 
 Switching **rich → plain** converts the Lexical state to Markdown via `$convertToMarkdownString(CUSTOM_TRANSFORMERS)` and loads it into the textarea. Switching **plain → rich** parses the textarea content back via `$convertFromMarkdownString`. The selected mode is persisted in `settings.json` as `editor_mode` and restored on next launch.

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,34 @@ li[role="checkbox"][aria-checked="true"] > span {
   font-style: italic;
 }
 
+/* Inline marker decoration: bold (**text**) */
+.prose :where(strong):not(:where([class~="not-prose"] *))::before,
+.prose :where(strong):not(:where([class~="not-prose"] *))::after {
+  content: "**";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 0.9em;
+  opacity: 0.55;
+}
+
+/* Inline marker decoration: italic (*text*) */
+.prose .editor-italic::before,
+.prose .editor-italic::after {
+  content: "*";
+  font-style: normal;
+  font-size: 0.9em;
+  opacity: 0.55;
+}
+
+/* Inline marker decoration: strikethrough (~~text~~) */
+.prose .editor-strikethrough::before,
+.prose .editor-strikethrough::after {
+  content: "~~";
+  text-decoration: none;
+  font-size: 0.9em;
+  opacity: 0.55;
+}
+
 @media (prefers-color-scheme: dark) {
   li[role="checkbox"]::before {
     border-color: #6b7280;

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,7 @@
 .prose :where(blockquote):not(:where([class~="not-prose"] *)) {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
+  font-style: normal;
 }
 
 /* Compact spacing: code blocks */

--- a/src/index.css
+++ b/src/index.css
@@ -130,6 +130,13 @@ li[role="checkbox"][aria-checked="true"] > span {
   font-style: italic;
 }
 
+/* Inline marker decoration: inline code (`code`) */
+.prose :where(code):not(:where([class~="not-prose"] *))::before,
+.prose :where(code):not(:where([class~="not-prose"] *))::after {
+  font-size: 0.9em;
+  opacity: 0.55;
+}
+
 /* Inline marker decoration: bold (**text**) */
 .prose :where(strong):not(:where([class~="not-prose"] *))::before,
 .prose :where(strong):not(:where([class~="not-prose"] *))::after {

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,20 @@
   margin-bottom: 0.2em;
 }
 
+/* Inline marker decoration: headings (#, ##, ...) */
+.prose :where(h1):not(:where([class~="not-prose"] *))::before { content: "#"; }
+.prose :where(h2):not(:where([class~="not-prose"] *))::before { content: "##"; }
+.prose :where(h3):not(:where([class~="not-prose"] *))::before { content: "###"; }
+.prose :where(h4):not(:where([class~="not-prose"] *))::before { content: "####"; }
+.prose :where(h5):not(:where([class~="not-prose"] *))::before { content: "#####"; }
+.prose :where(h6):not(:where([class~="not-prose"] *))::before { content: "######"; }
+.prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"] *))::before {
+  font-weight: normal;
+  font-size: 0.75em;
+  opacity: 0.4;
+  margin-right: 0.15em;
+}
+
 /* Compact spacing: blockquotes */
 .prose :where(blockquote):not(:where([class~="not-prose"] *)) {
   margin-top: 0.5em;


### PR DESCRIPTION
Closes #152

## Summary

- Add CSS `::before`/`::after` pseudo-elements to render Markdown syntax markers visibly in the rich editor (bold `**`, italic `*`, strikethrough `~~`, inline code `` ` ``, headings `#`–`######`)
- Fix blockquote italic style applied by Tailwind Typography default
- Update `docs/REQUIREMENTS.md` and `docs/SPEC.md` to document the marker rendering behavior

## Changes

### `src/index.css`
- **Bold/italic/strikethrough markers**: `::before`/`::after` with `font-size: 0.9em`, `opacity: 0.55`; `font-weight: normal` / `font-style: normal` / `text-decoration: none` to prevent markers from inheriting the formatted style
- **Inline code markers**: override Tailwind Typography defaults with `font-size: 0.9em`, `opacity: 0.55` for visual consistency
- **Heading markers**: `::before` for `h1`–`h6` with the corresponding `#` count; `font-size: 0.75em`, `opacity: 0.4`, `margin-right: 0.15em`, `font-weight: normal`
- **Blockquote**: add `font-style: normal` to override Tailwind Typography's default italic

### Docs
- `docs/REQUIREMENTS.md`: note that syntax markers (including strikethrough) are visible in the editor and CSS-only
- `docs/SPEC.md`: add technical note in §6.1 explaining the pseudo-element approach

## Test plan

- [x] `**bold**` → `**` markers visible, dimmed
- [x] `*italic*` → `*` markers visible, not italic
- [x] `***bold-italic***` → `***` markers visible
- [x] `~~strikethrough~~` → `~~` markers visible, no strikethrough on markers
- [x] `` `code` `` → backtick markers visible, dimmed (consistent with others)
- [x] `# H1` ~ `###### H6` → correct number of `#` markers, dimmed
- [x] Blockquote → text renders in normal (non-italic) style
- [x] Send to Clipboard → clipboard output contains no visual markers