### PR TITLE
ci: enable auto-generated release notes for GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
           # other workflows (e.g. homebrew-tap). Events fired by GITHUB_TOKEN do
           # not trigger subsequent workflow runs by design.
           token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          generate_release_notes: true
           files: |
             popmark-*-macos.zip
             src-tauri/target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
## Summary

- Add `generate_release_notes: true` to the `softprops/action-gh-release` step
- GitHub's built-in API will automatically list merged PRs since the previous release tag in the release body