### PR TITLE
feat: add setting to toggle syntax markers visibility in Rich Editor

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -22,7 +22,7 @@ Popmark is an application with a tray icon and standard menu bar, providing a qu
   - **Plain text mode**: displays the raw Markdown source in a monospaced textarea; no visual formatting is applied.
 - The selected mode is persisted and restored on next launch.
 - Supported Markdown elements: headings H1–H6, bold, italic, bold+italic, strikethrough, inline code, fenced code blocks (with optional language tag), blockquotes, unordered and ordered lists, checkbox (task) lists, horizontal rules, and links.
-- Inline syntax markers remain visible in the editor for inline code (`` ` ``), bold (`**`), italic (`*`), bold+italic (`***`), and strikethrough (`~~`), rendered in a dimmed, smaller style alongside the formatted text. These markers are CSS-only and do not appear in the clipboard output.
+- Inline syntax markers for inline code (`` ` ``), bold (`**`), italic (`*`), bold+italic (`***`), and strikethrough (`~~`) are rendered in a dimmed, smaller style alongside the formatted text. These markers are CSS-only and do not appear in the clipboard output. Their visibility can be toggled via the **"Show syntax markers"** setting (default: on).
 - Checkbox lists use `- [ ]` (unchecked) and `- [x]` (checked) syntax.
 - Standard Markdown syntax is used (`#` for H1, `##` for H2, etc.).
 - Pressing Enter on a blank list item exits list mode and returns to normal paragraph mode.
@@ -117,6 +117,7 @@ The next time the editor is opened it shows a blank document.
 | Rich mode font size | Custom font size (in px) for the Rich mode editor. When empty, the default size is used. |
 | Plain mode font family | Custom font family for the Plain mode textarea. When empty, the default monospace font is used. |
 | Plain mode font size | Custom font size (in px) for the Plain mode textarea. When empty, the default size is used. |
+| Show syntax markers | When enabled (Rich mode only), displays Markdown syntax markers (`**`, `*`, `~~`, `` ` ``, `#`–`######`) as CSS decorations alongside the formatted text (default: on). |
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -64,7 +64,7 @@ The editor supports two modes, toggled via the toolbar button (**⌘⇧R** for R
 
 - **Rich mode** (default): **source-visible WYSIWYG** (Obsidian style) — Markdown syntax markers (`#`, `**`, `` ` ``, etc.) remain visible in the editor while visual styling is applied at the same time (font size, weight, color, etc.). The user can edit the raw markers directly, and the styling updates live.
 
-Inline syntax markers for bold (`**`), italic (`*`), bold+italic (`***`), and strikethrough (`~~`) are rendered as CSS pseudo-elements (`::before` / `::after`) in a dimmed, slightly smaller style. This is purely visual: the markers are not part of the DOM text content and do not appear in clipboard output.
+Inline syntax markers for bold (`**`), italic (`*`), bold+italic (`***`), strikethrough (`~~`), inline code (`` ` ``), and headings (`#`–`######`) are rendered as CSS pseudo-elements (`::before` / `::after`) in a dimmed, slightly smaller style. This is purely visual: the markers are not part of the DOM text content and do not appear in clipboard output. Visibility is controlled by the `rich_show_syntax_markers` setting: when `true`, the `.show-syntax-markers` class is applied to the `ContentEditable` element, activating the marker CSS rules; when `false`, the class is absent and no markers are shown.
 - **Plain text mode**: a plain `<textarea>` displays the raw Markdown source. `spellCheck` is disabled and all Lexical formatting plugins are inactive.
 
 Switching **rich → plain** converts the Lexical state to Markdown via `$convertToMarkdownString(CUSTOM_TRANSFORMERS)` and loads it into the textarea. Switching **plain → rich** parses the textarea content back via `$convertFromMarkdownString`. The selected mode is persisted in `settings.json` as `editor_mode` and restored on next launch.
@@ -298,6 +298,7 @@ After the user saves, the backend emits a `settings-changed` event to the main w
 | Copy as Rich Text    | Off                | When enabled (Rich mode only), "Send to Clipboard" copies HTML + plain Markdown so rich formatting is preserved in apps that support it |
 | Max history entries  | 0 (unlimited)      | Maximum number of history entries to retain; oldest are auto-deleted when a new entry exceeds the limit |
 | Notify on copy       | On                 | When enabled, an OS notification is sent after "Send to Clipboard". Stored as `notify_on_copy` in `settings.json`. |
+| Show syntax markers  | On                 | When enabled (Rich mode only), displays Markdown syntax markers as CSS pseudo-elements. Applies the `.show-syntax-markers` class to the `ContentEditable`. Stored as `rich_show_syntax_markers` in `settings.json`. Defaults to `true` when absent. |
 | Rich mode font family | null (browser default) | Custom `font-family` applied to the Rich mode `ContentEditable` via inline style |
 | Rich mode font size  | null (default)     | Custom `font-size` (px) applied to the Rich mode `ContentEditable` via inline style |
 | Plain mode font family | null (browser default) | Custom `font-family` applied to the Plain mode `<textarea>` via inline style |
@@ -317,11 +318,12 @@ After the user saves, the backend emits a `settings-changed` event to the main w
   "plain_font_family": null,
   "plain_font_size": null,
   "send_shortcut": "super+enter",
-  "notify_on_copy": true
+  "notify_on_copy": true,
+  "rich_show_syntax_markers": true
 }
 ```
 
-All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`).
+All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`). `rich_show_syntax_markers` defaults to `true` when absent (`#[serde(default = "default_rich_show_syntax_markers")]`).
 
 ---
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -61,12 +61,15 @@ pub struct Settings {
     pub send_shortcut: String,
     #[serde(default = "default_notify_on_copy")]
     pub notify_on_copy: bool,
+    #[serde(default = "default_rich_show_syntax_markers")]
+    pub rich_show_syntax_markers: bool,
 }
 
 const DEFAULT_EDITOR_MODE: &str = "rich";
 const DEFAULT_SEND_SHORTCUT: &str = "super+enter";
 const DEFAULT_FONT_FALLBACK: bool = true;
 const DEFAULT_NOTIFY_ON_COPY: bool = true;
+const DEFAULT_RICH_SHOW_SYNTAX_MARKERS: bool = true;
 
 fn default_editor_mode() -> String {
     DEFAULT_EDITOR_MODE.to_string()
@@ -82,6 +85,10 @@ fn default_send_shortcut() -> String {
 
 fn default_notify_on_copy() -> bool {
     DEFAULT_NOTIFY_ON_COPY
+}
+
+fn default_rich_show_syntax_markers() -> bool {
+    DEFAULT_RICH_SHOW_SYNTAX_MARKERS
 }
 
 impl Default for Settings {
@@ -100,6 +107,7 @@ impl Default for Settings {
             plain_font_fallback: DEFAULT_FONT_FALLBACK,
             send_shortcut: DEFAULT_SEND_SHORTCUT.to_string(),
             notify_on_copy: DEFAULT_NOTIFY_ON_COPY,
+            rich_show_syntax_markers: DEFAULT_RICH_SHOW_SYNTAX_MARKERS,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ function App() {
   const [richFontSize, setRichFontSize] = useState<number | null>(null);
   const [plainFontFamily, setPlainFontFamily] = useState<string | null>(null);
   const [plainFontSize, setPlainFontSize] = useState<number | null>(null);
+  const [richShowSyntaxMarkers, setRichShowSyntaxMarkers] = useState<boolean>(true);
 
   useEffect(() => {
     invoke<Settings>("get_settings").then((s) => {
@@ -24,6 +25,7 @@ function App() {
         composeFontFamily(s.plain_font_family, s.plain_font_fallback, PLAIN_FALLBACK_STACK),
       );
       setPlainFontSize(s.plain_font_size ?? null);
+      setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
       setSettingsLoaded(true);
     });
   }, []);
@@ -39,6 +41,7 @@ function App() {
         composeFontFamily(s.plain_font_family, s.plain_font_fallback, PLAIN_FALLBACK_STACK),
       );
       setPlainFontSize(s.plain_font_size ?? null);
+      setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
     });
     return () => {
       unlisten.then((fn) => fn());
@@ -61,6 +64,7 @@ function App() {
         richFontSize={richFontSize}
         plainFontFamily={plainFontFamily}
         plainFontSize={plainFontSize}
+        richShowSyntaxMarkers={richShowSyntaxMarkers}
       />
     </div>
   );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -65,6 +65,7 @@ export function SettingsPanel() {
   const [launchAtLogin, setLaunchAtLogin] = useState(false);
   const [copyAsRichText, setCopyAsRichText] = useState(false);
   const [notifyOnCopy, setNotifyOnCopy] = useState<boolean>(true);
+  const [richShowSyntaxMarkers, setRichShowSyntaxMarkers] = useState<boolean>(true);
   const [maxHistoryEntries, setMaxHistoryEntries] = useState<string>("");
   const [fontState, dispatchFont] = useReducer(fontReducer, initialFontState);
   const [fontList, setFontList] = useState<string[]>([]);
@@ -78,6 +79,7 @@ export function SettingsPanel() {
         setLaunchAtLogin(s.launch_at_login);
         setCopyAsRichText(s.copy_as_rich_text);
         setNotifyOnCopy(s.notify_on_copy ?? true);
+        setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
         const limit = s.max_history_entries;
         setMaxHistoryEntries(limit != null && limit > 0 ? String(limit) : "");
         const sendShortcut = s.send_shortcut ?? "super+enter";
@@ -148,6 +150,7 @@ export function SettingsPanel() {
         plain_font_fallback: fontState.plainFontFallback,
         send_shortcut: capturedSendShortcut,
         notify_on_copy: notifyOnCopy,
+        rich_show_syntax_markers: richShowSyntaxMarkers,
       },
     });
     setSavedHotkey(capturedHotkey);
@@ -243,6 +246,19 @@ export function SettingsPanel() {
             />
           </label>
         </div>
+
+        {/* Show syntax markers in Rich Editor */}
+        <CheckboxSetting
+          checked={richShowSyntaxMarkers}
+          onChange={setRichShowSyntaxMarkers}
+          label={
+            <>
+              Show syntax markers{" "}
+              <span className="text-xs text-gray-400 dark:text-gray-500">(Rich mode only)</span>
+            </>
+          }
+          className="mb-4"
+        />
 
         {/* Font settings: Rich | Plain in 2 columns */}
         <div className="grid grid-cols-2 gap-4 mb-6">

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -274,6 +274,7 @@ interface MarkdownEditorProps {
   richFontSize?: number | null;
   plainFontFamily?: string | null;
   plainFontSize?: number | null;
+  richShowSyntaxMarkers?: boolean;
 }
 
 export function MarkdownEditor({
@@ -283,6 +284,7 @@ export function MarkdownEditor({
   richFontSize,
   plainFontFamily,
   plainFontSize,
+  richShowSyntaxMarkers = true,
 }: MarkdownEditorProps) {
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [pendingContent, setPendingContent] = useState<string | null>(null);
@@ -459,7 +461,7 @@ export function MarkdownEditor({
               <RichTextPlugin
                 contentEditable={
                   <ContentEditable
-                    className="h-full overflow-y-auto p-4 outline-none prose prose-sm dark:prose-invert max-w-none"
+                    className={`h-full overflow-y-auto p-4 outline-none prose prose-sm dark:prose-invert max-w-none${richShowSyntaxMarkers ? " show-syntax-markers" : ""}`}
                     style={{
                       fontFamily: richFontFamily ?? undefined,
                       fontSize: richFontSize ? `${richFontSize}px` : undefined,

--- a/src/index.css
+++ b/src/index.css
@@ -15,13 +15,13 @@
 }
 
 /* Inline marker decoration: headings (#, ##, ...) */
-.prose :where(h1):not(:where([class~="not-prose"] *))::before { content: "#"; }
-.prose :where(h2):not(:where([class~="not-prose"] *))::before { content: "##"; }
-.prose :where(h3):not(:where([class~="not-prose"] *))::before { content: "###"; }
-.prose :where(h4):not(:where([class~="not-prose"] *))::before { content: "####"; }
-.prose :where(h5):not(:where([class~="not-prose"] *))::before { content: "#####"; }
-.prose :where(h6):not(:where([class~="not-prose"] *))::before { content: "######"; }
-.prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"] *))::before {
+.show-syntax-markers.prose :where(h1):not(:where([class~="not-prose"] *))::before { content: "#"; }
+.show-syntax-markers.prose :where(h2):not(:where([class~="not-prose"] *))::before { content: "##"; }
+.show-syntax-markers.prose :where(h3):not(:where([class~="not-prose"] *))::before { content: "###"; }
+.show-syntax-markers.prose :where(h4):not(:where([class~="not-prose"] *))::before { content: "####"; }
+.show-syntax-markers.prose :where(h5):not(:where([class~="not-prose"] *))::before { content: "#####"; }
+.show-syntax-markers.prose :where(h6):not(:where([class~="not-prose"] *))::before { content: "######"; }
+.show-syntax-markers.prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"] *))::before {
   font-weight: normal;
   font-size: 0.75em;
   opacity: 0.4;
@@ -131,15 +131,15 @@ li[role="checkbox"][aria-checked="true"] > span {
 }
 
 /* Inline marker decoration: inline code (`code`) */
-.prose :where(code):not(:where([class~="not-prose"] *))::before,
-.prose :where(code):not(:where([class~="not-prose"] *))::after {
+.show-syntax-markers.prose :where(code):not(:where([class~="not-prose"] *))::before,
+.show-syntax-markers.prose :where(code):not(:where([class~="not-prose"] *))::after {
   font-size: 0.9em;
   opacity: 0.55;
 }
 
 /* Inline marker decoration: bold (**text**) */
-.prose :where(strong):not(:where([class~="not-prose"] *))::before,
-.prose :where(strong):not(:where([class~="not-prose"] *))::after {
+.show-syntax-markers.prose :where(strong):not(:where([class~="not-prose"] *))::before,
+.show-syntax-markers.prose :where(strong):not(:where([class~="not-prose"] *))::after {
   content: "**";
   font-weight: normal;
   font-style: normal;
@@ -148,8 +148,8 @@ li[role="checkbox"][aria-checked="true"] > span {
 }
 
 /* Inline marker decoration: italic (*text*) */
-.prose .editor-italic::before,
-.prose .editor-italic::after {
+.show-syntax-markers.prose .editor-italic::before,
+.show-syntax-markers.prose .editor-italic::after {
   content: "*";
   font-style: normal;
   font-size: 0.9em;
@@ -157,8 +157,8 @@ li[role="checkbox"][aria-checked="true"] > span {
 }
 
 /* Inline marker decoration: strikethrough (~~text~~) */
-.prose .editor-strikethrough::before,
-.prose .editor-strikethrough::after {
+.show-syntax-markers.prose .editor-strikethrough::before,
+.show-syntax-markers.prose .editor-strikethrough::after {
   content: "~~";
   text-decoration: none;
   font-size: 0.9em;

--- a/src/index.css
+++ b/src/index.css
@@ -131,8 +131,14 @@ li[role="checkbox"][aria-checked="true"] > span {
 }
 
 /* Inline marker decoration: inline code (`code`) */
+/* Reset Tailwind Typography default backtick content unconditionally */
+.prose :where(code):not(:where([class~="not-prose"] *))::before,
+.prose :where(code):not(:where([class~="not-prose"] *))::after {
+  content: none;
+}
 .show-syntax-markers.prose :where(code):not(:where([class~="not-prose"] *))::before,
 .show-syntax-markers.prose :where(code):not(:where([class~="not-prose"] *))::after {
+  content: "`";
   font-size: 0.9em;
   opacity: 0.55;
 }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -14,4 +14,5 @@ export interface Settings {
   plain_font_fallback?: boolean;
   send_shortcut?: string;
   notify_on_copy?: boolean;
+  rich_show_syntax_markers?: boolean;
 }


### PR DESCRIPTION
Closes #154

## Summary

- Adds a new boolean setting **"Show syntax markers"** (default: `true`) in the Settings panel
- When disabled, hides the `**`, `*`, `~~`, `` ` ``, and `#`–`######` CSS pseudo-element decorations in Rich Editor
- Existing users without the setting in their config file default to `true` (current behavior preserved) via `#[serde(default)]`

## Implementation

- `src-tauri/src/commands.rs`: Added `rich_show_syntax_markers` field with `serde(default)` defaulting to `true`
- `src/types/settings.ts`: Added optional `rich_show_syntax_markers` field
- `src/components/SettingsPanel.tsx`: Added `CheckboxSetting` for the new option
- `src/App.tsx`: Reads setting on load and on `settings-changed` event, passes to `MarkdownEditor`
- `src/editor/MarkdownEditor.tsx`: Conditionally applies `show-syntax-markers` class to `ContentEditable`
- `src/index.css`: Scoped all syntax marker `::before`/`::after` rules under `.show-syntax-markers.prose`

## Test plan

- [x] Open Settings → verify "Show syntax markers (Rich mode only)" checkbox is present and checked by default
- [x] Uncheck it → Save → confirm `**`, `*`, `~~`, `` ` ``, `#` markers disappear in Rich Editor
- [x] Re-check it → Save → confirm markers reappear
- [x] Verify Plain mode is unaffected by the setting
- [ ] Delete or remove `rich_show_syntax_markers` from the settings JSON → restart → confirm markers show (defaults to `true`)