### PR TITLE
fix: override typography max-width via inline style to fix Rich editor width

### DIFF
--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -461,10 +461,11 @@ export function MarkdownEditor({
               <RichTextPlugin
                 contentEditable={
                   <ContentEditable
-                    className={`h-full overflow-y-auto p-4 outline-none prose prose-sm dark:prose-invert max-w-none${richShowSyntaxMarkers ? " show-syntax-markers" : ""}`}
+                    className={`w-full h-full overflow-y-auto p-4 outline-none prose prose-sm dark:prose-invert${richShowSyntaxMarkers ? " show-syntax-markers" : ""}`}
                     style={{
                       fontFamily: richFontFamily ?? undefined,
                       fontSize: richFontSize ? `${richFontSize}px` : undefined,
+                      maxWidth: "none",
                     }}
                   />
                 }


### PR DESCRIPTION
## Summary

- Fixes Rich mode editor width not adapting to window resize (closes #157)
- Root cause: `@tailwindcss/typography` sets `max-width: 65ch` as unlayered CSS, which outweighs `max-w-none` in `@layer utilities` per CSS cascade layer spec
- Fix: remove the ineffective `max-w-none` class; set `maxWidth: "none"` as an inline style, which is outside the cascade layer system and always wins

## Test plan

- [x] Open popmark in Rich mode
- [x] Resize the window wider and narrower — editor should fill the full width at all sizes
- [x] Scrollbar should appear flush with the window's right edge
- [x] Long text should wrap at the window width, not before it
- [x] Plain mode is unaffected