### PR TITLE
feat: suppress context menu outside editor and add DevTools menu in debug builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -192,13 +192,8 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     )?;
     let menu_help_item = MenuItem::with_id(app, "menu-help", "Popmark Help", true, Some("cmd+?"))?;
     #[cfg(debug_assertions)]
-    let menu_devtools_item = MenuItem::with_id(
-        app,
-        "menu-devtools",
-        "Developer Tools",
-        true,
-        None::<&str>,
-    )?;
+    let menu_devtools_item =
+        MenuItem::with_id(app, "menu-devtools", "Developer Tools", true, None::<&str>)?;
     let menu_paste_and_match_style_item = MenuItem::with_id(
         app,
         "menu-paste-and-match-style",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,14 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         None::<&str>,
     )?;
     let menu_help_item = MenuItem::with_id(app, "menu-help", "Popmark Help", true, Some("cmd+?"))?;
+    #[cfg(debug_assertions)]
+    let menu_devtools_item = MenuItem::with_id(
+        app,
+        "menu-devtools",
+        "Developer Tools",
+        true,
+        None::<&str>,
+    )?;
     let menu_paste_and_match_style_item = MenuItem::with_id(
         app,
         "menu-paste-and-match-style",
@@ -219,6 +227,19 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         true,
         Some("cmd+shift+backspace"),
     )?;
+    #[cfg(debug_assertions)]
+    let help_submenu = Submenu::with_items(
+        app,
+        "Help",
+        true,
+        &[
+            &menu_help_item,
+            &PredefinedMenuItem::separator(app)?,
+            &menu_devtools_item,
+        ],
+    )?;
+    #[cfg(not(debug_assertions))]
+    let help_submenu = Submenu::with_items(app, "Help", true, &[&menu_help_item])?;
     let menu = Menu::with_items(
         app,
         &[
@@ -288,7 +309,7 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                     &menu_move_to_center_item,
                 ],
             )?,
-            &Submenu::with_items(app, "Help", true, &[&menu_help_item])?,
+            &help_submenu,
         ],
     )?;
     app.set_menu(menu)?;
@@ -381,6 +402,12 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         }
         "menu-help" => {
             // stub: no help documentation yet
+        }
+        #[cfg(debug_assertions)]
+        "menu-devtools" => {
+            if let Some(window) = app.get_webview_window("main") {
+                window.open_devtools();
+            }
         }
         _ => {}
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,17 @@ function App() {
     };
   }, []);
 
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Element | null;
+      // Allow context menu inside the editor (contenteditable for rich, textarea for plain)
+      if (target?.closest("[contenteditable]") || target?.closest("textarea")) return;
+      e.preventDefault();
+    };
+    document.addEventListener("contextmenu", handler);
+    return () => document.removeEventListener("contextmenu", handler);
+  }, []);
+
   const handleModeChange = useCallback((mode: EditorMode) => {
     setEditorMode(mode);
     invoke("save_editor_mode", { mode });


### PR DESCRIPTION
## Summary

- Suppress the WebView default right-click context menu (Reload, Inspect Element) everywhere except inside the editor. In rich mode the `[contenteditable]` element is allowed; in plain mode the `<textarea>` is allowed.
- Add a **Developer Tools** menu item under Help in the macOS application menu, visible only in debug builds (`#[cfg(debug_assertions)]`). Clicking it opens the WebView DevTools for the main window.

## Changes

- `src/App.tsx` — global `contextmenu` listener that calls `preventDefault()` unless the target is inside the editor area
- `src-tauri/src/lib.rs` — `menu-devtools` menu item and handler, conditioned on `debug_assertions`; Help submenu branches between debug (with DevTools) and release (without)

## Test plan

- [x] `npm run tauri dev`: right-click on toolbar/title bar → no context menu appears
- [x] `npm run tauri dev`: right-click inside editor text area → native context menu appears
- [x] `npm run tauri dev`: Help menu shows "Popmark Help", a separator, and "Developer Tools"
- [x] `npm run tauri dev`: clicking "Developer Tools" opens the DevTools panel
- [x] `npm run tauri build`: Help menu shows "Popmark Help" only (no separator, no Developer Tools)