### PR TITLE
feat: improve link rendering and interaction in Rich mode

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "clipboard-manager:allow-write-text",
     "clipboard-manager:allow-write-html",
     "clipboard-manager:allow-read-text",
-    "dialog:allow-confirm"
+    "dialog:allow-confirm",
+    "opener:allow-open-url"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "clipboard-manager:allow-write-html",
     "clipboard-manager:allow-read-text",
     "dialog:allow-confirm",
-    "opener:allow-open-url"
+    "opener:allow-open-url",
+    "opener:allow-default-urls"
   ]
 }

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -1,6 +1,5 @@
 import { $convertFromMarkdownString, $convertToMarkdownString } from "@lexical/markdown";
 import { CheckListPlugin } from "@lexical/react/LexicalCheckListPlugin";
-import { ClickableLinkPlugin } from "@lexical/react/LexicalClickableLinkPlugin";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
@@ -32,6 +31,7 @@ import { CodeEnterPlugin } from "./plugins/CodeEnterPlugin";
 import { CodeExitPlugin } from "./plugins/CodeExitPlugin";
 import { InlineCodeEscapePlugin } from "./plugins/InlineCodeEscapePlugin";
 import { InlineCodeFormatResetPlugin } from "./plugins/InlineCodeFormatResetPlugin";
+import { LinkPopoverPlugin } from "./plugins/LinkPopoverPlugin";
 import { ListShiftTabExitPlugin } from "./plugins/ListShiftTabExitPlugin";
 import { CUSTOM_TRANSFORMERS } from "./transformers";
 
@@ -482,7 +482,7 @@ export function MarkdownEditor({
               <ListPlugin />
               <CheckListPlugin />
               <TabIndentationPlugin />
-              <ClickableLinkPlugin newTab={false} />
+              <LinkPopoverPlugin />
               <CodeEnterPlugin />
               <CodeExitPlugin />
               <ListShiftTabExitPlugin />

--- a/src/editor/plugins/LinkPopoverPlugin.tsx
+++ b/src/editor/plugins/LinkPopoverPlugin.tsx
@@ -1,0 +1,222 @@
+import { $isLinkNode } from "@lexical/link";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  $findMatchingParent,
+  $getNearestNodeFromDOMNode,
+} from "lexical";
+import { $getNodeByKey, $getSelection, $isRangeSelection } from "lexical";
+import { ExternalLink } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface PopoverState {
+  nodeKey: string;
+  url: string;
+}
+
+interface LinkPopoverProps {
+  state: PopoverState;
+  position: { top: number; left: number };
+  onSave: (nodeKey: string, url: string) => void;
+  onClose: () => void;
+}
+
+function LinkPopover({ state, position, onSave, onClose }: LinkPopoverProps) {
+  const [editingUrl, setEditingUrl] = useState(state.url);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  // Use a native keydown listener so stopImmediatePropagation reaches the
+  // window-level handler in EditorPlugins (React synthetic events can't do this).
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        onClose();
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        onSave(state.nodeKey, editingUrl);
+      }
+    };
+    input.addEventListener("keydown", handleKeyDown);
+    return () => input.removeEventListener("keydown", handleKeyDown);
+  }, [state.nodeKey, editingUrl, onSave, onClose]);
+
+  const handleOpenInBrowser = useCallback(async () => {
+    if (editingUrl) {
+      await invoke("plugin:opener|open_url", { url: editingUrl });
+    }
+  }, [editingUrl]);
+
+  // Clamp to viewport so the popover doesn't clip at screen edges
+  const top = Math.min(position.top + 4, window.innerHeight - 48);
+  const left = Math.min(position.left, window.innerWidth - 320);
+
+  return createPortal(
+    <div
+      style={{ position: "fixed", top, left, zIndex: 9999 }}
+      className="flex items-center gap-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg p-1"
+      // Prevent native mousedown from reaching the window close-on-outside handler
+      onMouseDown={(e) => e.nativeEvent.stopImmediatePropagation()}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={editingUrl}
+        onChange={(e) => setEditingUrl(e.target.value)}
+        className="text-sm px-2 py-1 outline-none bg-transparent w-52 text-gray-900 dark:text-gray-100"
+        placeholder="Enter URL…"
+      />
+      <button
+        type="button"
+        onClick={handleOpenInBrowser}
+        className="p-1 text-gray-500 hover:text-blue-500 dark:text-gray-400 dark:hover:text-blue-400 rounded"
+        title="Open in browser"
+      >
+        <ExternalLink size={14} />
+      </button>
+    </div>,
+    document.body,
+  );
+}
+
+export function LinkPopoverPlugin() {
+  const [editor] = useLexicalComposerContext();
+  const [popoverState, setPopoverState] = useState<PopoverState | null>(null);
+  const [popoverPosition, setPopoverPosition] = useState({ top: 0, left: 0 });
+
+  const closePopover = useCallback(() => {
+    setPopoverState(null);
+    editor.focus();
+  }, [editor]);
+
+  const saveUrl = useCallback(
+    (nodeKey: string, url: string) => {
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if ($isLinkNode(node)) {
+          node.setURL(url);
+        }
+      });
+      setPopoverState(null);
+      editor.focus();
+    },
+    [editor],
+  );
+
+  const openPopoverForElement = useCallback(
+    (nodeKey: string, url: string, anchorElement: Element) => {
+      const rect = anchorElement.getBoundingClientRect();
+      setPopoverPosition({ top: rect.bottom, left: rect.left });
+      setPopoverState({ nodeKey, url });
+    },
+    [],
+  );
+
+  // Cmd+E: open popover when cursor is inside a link
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!((e.metaKey || e.ctrlKey) && e.key === "e" && !e.shiftKey)) return;
+
+      let foundKey: string | null = null;
+      let foundUrl = "";
+
+      editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        const node = selection.anchor.getNode();
+        const linkNode = $findMatchingParent(node, $isLinkNode);
+        if ($isLinkNode(linkNode)) {
+          foundKey = linkNode.getKey();
+          foundUrl = linkNode.getURL();
+        }
+      });
+
+      if (!foundKey) return;
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      const linkElement = editor.getElementByKey(foundKey);
+      if (linkElement) {
+        openPopoverForElement(foundKey, foundUrl, linkElement);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  }, [editor, openPopoverForElement]);
+
+  // Link click: prevent in-app navigation and open popover
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const anchorElement = target.closest("a[href]");
+      if (!anchorElement) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      let foundKey: string | null = null;
+      let foundUrl = "";
+
+      editor.getEditorState().read(() => {
+        // Walk up from the clicked DOM node to find the Lexical LinkNode
+        const lexicalNode = $getNearestNodeFromDOMNode(target);
+        if (!lexicalNode) return;
+        const linkNode = $isLinkNode(lexicalNode)
+          ? lexicalNode
+          : $findMatchingParent(lexicalNode, $isLinkNode);
+        if ($isLinkNode(linkNode)) {
+          foundKey = linkNode.getKey();
+          foundUrl = linkNode.getURL();
+        }
+      });
+
+      if (!foundKey) {
+        // Fallback: read URL from DOM when Lexical lookup fails
+        foundUrl = (anchorElement as HTMLAnchorElement).getAttribute("href") ?? "";
+      }
+
+      openPopoverForElement(
+        foundKey ?? "",
+        foundUrl,
+        anchorElement,
+      );
+    };
+
+    const root = editor.getRootElement();
+    if (!root) return;
+    root.addEventListener("click", handleClick, { capture: true });
+    return () => root.removeEventListener("click", handleClick, { capture: true });
+  }, [editor, openPopoverForElement]);
+
+  // Close popover when clicking outside
+  useEffect(() => {
+    if (!popoverState) return;
+    const handleOutsideMouseDown = () => {
+      setPopoverState(null);
+    };
+    window.addEventListener("mousedown", handleOutsideMouseDown);
+    return () => window.removeEventListener("mousedown", handleOutsideMouseDown);
+  }, [popoverState]);
+
+  if (!popoverState) return null;
+
+  return (
+    <LinkPopover
+      state={popoverState}
+      position={popoverPosition}
+      onSave={saveUrl}
+      onClose={closePopover}
+    />
+  );
+}

--- a/src/editor/plugins/LinkPopoverPlugin.tsx
+++ b/src/editor/plugins/LinkPopoverPlugin.tsx
@@ -4,8 +4,12 @@ import { invoke } from "@tauri-apps/api/core";
 import {
   $findMatchingParent,
   $getNearestNodeFromDOMNode,
+  $getNodeByKey,
+  $getSelection,
+  $isRangeSelection,
+  CLICK_COMMAND,
+  COMMAND_PRIORITY_LOW,
 } from "lexical";
-import { $getNodeByKey, $getSelection, $isRangeSelection } from "lexical";
 import { ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -20,9 +24,10 @@ interface LinkPopoverProps {
   position: { top: number; left: number };
   onSave: (nodeKey: string, url: string) => void;
   onClose: () => void;
+  popoverRef: React.RefObject<HTMLDivElement | null>;
 }
 
-function LinkPopover({ state, position, onSave, onClose }: LinkPopoverProps) {
+function LinkPopover({ state, position, onSave, onClose, popoverRef }: LinkPopoverProps) {
   const [editingUrl, setEditingUrl] = useState(state.url);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -63,10 +68,9 @@ function LinkPopover({ state, position, onSave, onClose }: LinkPopoverProps) {
 
   return createPortal(
     <div
+      ref={popoverRef}
       style={{ position: "fixed", top, left, zIndex: 9999 }}
       className="flex items-center gap-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg p-1"
-      // Prevent native mousedown from reaching the window close-on-outside handler
-      onMouseDown={(e) => e.nativeEvent.stopImmediatePropagation()}
     >
       <input
         ref={inputRef}
@@ -93,6 +97,7 @@ export function LinkPopoverPlugin() {
   const [editor] = useLexicalComposerContext();
   const [popoverState, setPopoverState] = useState<PopoverState | null>(null);
   const [popoverPosition, setPopoverPosition] = useState({ top: 0, left: 0 });
+  const popoverRef = useRef<HTMLDivElement | null>(null);
 
   const closePopover = useCallback(() => {
     setPopoverState(null);
@@ -156,57 +161,54 @@ export function LinkPopoverPlugin() {
     return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
   }, [editor, openPopoverForElement]);
 
-  // Link click: prevent in-app navigation and open popover
+  // Link click: open popover. Use Lexical's CLICK_COMMAND so we don't depend
+  // on manual root-element wiring or event-listener ordering.
   useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      const anchorElement = target.closest("a[href]");
-      if (!anchorElement) return;
-      e.preventDefault();
-      e.stopPropagation();
+    return editor.registerCommand(
+      CLICK_COMMAND,
+      (event) => {
+        const target = event.target as HTMLElement | null;
+        const anchorElement = target?.closest("a[href]");
+        if (!anchorElement) return false;
 
-      let foundKey: string | null = null;
-      let foundUrl = "";
+        let foundKey: string | null = null;
+        let foundUrl = "";
 
-      editor.getEditorState().read(() => {
-        // Walk up from the clicked DOM node to find the Lexical LinkNode
-        const lexicalNode = $getNearestNodeFromDOMNode(target);
-        if (!lexicalNode) return;
-        const linkNode = $isLinkNode(lexicalNode)
-          ? lexicalNode
-          : $findMatchingParent(lexicalNode, $isLinkNode);
-        if ($isLinkNode(linkNode)) {
-          foundKey = linkNode.getKey();
-          foundUrl = linkNode.getURL();
+        const lexicalNode = $getNearestNodeFromDOMNode(anchorElement);
+        if (lexicalNode) {
+          const linkNode = $isLinkNode(lexicalNode)
+            ? lexicalNode
+            : $findMatchingParent(lexicalNode, $isLinkNode);
+          if ($isLinkNode(linkNode)) {
+            foundKey = linkNode.getKey();
+            foundUrl = linkNode.getURL();
+          }
         }
-      });
 
-      if (!foundKey) {
-        // Fallback: read URL from DOM when Lexical lookup fails
-        foundUrl = (anchorElement as HTMLAnchorElement).getAttribute("href") ?? "";
-      }
+        if (!foundKey) {
+          foundUrl = (anchorElement as HTMLAnchorElement).getAttribute("href") ?? "";
+        }
 
-      openPopoverForElement(
-        foundKey ?? "",
-        foundUrl,
-        anchorElement,
-      );
-    };
-
-    const root = editor.getRootElement();
-    if (!root) return;
-    root.addEventListener("click", handleClick, { capture: true });
-    return () => root.removeEventListener("click", handleClick, { capture: true });
+        event.preventDefault();
+        openPopoverForElement(foundKey ?? "", foundUrl, anchorElement);
+        return true;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
   }, [editor, openPopoverForElement]);
 
-  // Close popover when clicking outside
+  // Close popover when clicking outside. Use capture phase so we can decide
+  // before any other listener, and check containment so clicks on the popover
+  // itself (e.g. the "open in browser" icon) don't dismiss it before their
+  // own click handler runs.
   useEffect(() => {
     if (!popoverState) return;
-    const handleOutsideMouseDown = () => {
+    const handleOutsideMouseDown = (e: MouseEvent) => {
+      if (popoverRef.current?.contains(e.target as Node)) return;
       setPopoverState(null);
     };
-    window.addEventListener("mousedown", handleOutsideMouseDown);
-    return () => window.removeEventListener("mousedown", handleOutsideMouseDown);
+    window.addEventListener("mousedown", handleOutsideMouseDown, { capture: true });
+    return () => window.removeEventListener("mousedown", handleOutsideMouseDown, { capture: true });
   }, [popoverState]);
 
   if (!popoverState) return null;
@@ -217,6 +219,7 @@ export function LinkPopoverPlugin() {
       position={popoverPosition}
       onSave={saveUrl}
       onClose={closePopover}
+      popoverRef={popoverRef}
     />
   );
 }

--- a/src/editor/plugins/LinkPopoverPlugin.tsx
+++ b/src/editor/plugins/LinkPopoverPlugin.tsx
@@ -10,7 +10,7 @@ import {
   CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
 } from "lexical";
-import { ExternalLink } from "lucide-react";
+import { Check, ExternalLink, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -62,6 +62,10 @@ function LinkPopover({ state, position, onSave, onClose, popoverRef }: LinkPopov
     }
   }, [editingUrl]);
 
+  const handleSave = useCallback(() => {
+    onSave(state.nodeKey, editingUrl);
+  }, [state.nodeKey, editingUrl, onSave]);
+
   // Clamp to viewport so the popover doesn't clip at screen edges
   const top = Math.min(position.top + 4, window.innerHeight - 48);
   const left = Math.min(position.left, window.innerWidth - 320);
@@ -72,6 +76,14 @@ function LinkPopover({ state, position, onSave, onClose, popoverRef }: LinkPopov
       style={{ position: "fixed", top, left, zIndex: 9999 }}
       className="flex items-center gap-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg p-1"
     >
+      <button
+        type="button"
+        onClick={handleOpenInBrowser}
+        className="p-1 text-gray-500 hover:text-blue-500 dark:text-gray-400 dark:hover:text-blue-400 rounded"
+        title="Open in browser"
+      >
+        <ExternalLink size={14} />
+      </button>
       <input
         ref={inputRef}
         type="text"
@@ -82,11 +94,19 @@ function LinkPopover({ state, position, onSave, onClose, popoverRef }: LinkPopov
       />
       <button
         type="button"
-        onClick={handleOpenInBrowser}
-        className="p-1 text-gray-500 hover:text-blue-500 dark:text-gray-400 dark:hover:text-blue-400 rounded"
-        title="Open in browser"
+        onClick={handleSave}
+        className="p-1 text-gray-500 hover:text-green-500 dark:text-gray-400 dark:hover:text-green-400 rounded"
+        title="Save"
       >
-        <ExternalLink size={14} />
+        <Check size={14} />
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        className="p-1 text-gray-500 hover:text-red-500 dark:text-gray-400 dark:hover:text-red-400 rounded"
+        title="Cancel"
+      >
+        <X size={14} />
       </button>
     </div>,
     document.body,

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,51 @@ li[role="checkbox"][aria-checked="true"] > span {
   color: #9ca3af;
 }
 
+/* Link: blue color and pointer cursor */
+.prose :where(a):not(:where([class~="not-prose"] *)) {
+  color: #2563eb;
+  cursor: pointer;
+}
+@media (prefers-color-scheme: dark) {
+  .prose :where(a):not(:where([class~="not-prose"] *)) {
+    color: #60a5fa;
+  }
+}
+
+/* Inline marker decoration: links ([text]) */
+.show-syntax-markers.prose :where(a):not(:where([class~="not-prose"] *))::before {
+  content: "[";
+  font-size: 0.9em;
+  opacity: 0.55;
+  font-weight: normal;
+  font-style: normal;
+}
+.show-syntax-markers.prose :where(a):not(:where([class~="not-prose"] *))::after {
+  content: "]";
+  font-size: 0.9em;
+  opacity: 0.55;
+  font-weight: normal;
+  font-style: normal;
+}
+
+/* Inline marker decoration: link external icon (syntax markers OFF) */
+/* stylelint-disable-next-line */
+.prose:not(.show-syntax-markers) :where(a):not(:where([class~="not-prose"] *))::after {
+  content: "";
+  display: inline-block;
+  width: 0.72em;
+  height: 0.72em;
+  margin-left: 0.18em;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6'/%3E%3Cpath d='m21 3-9 9'/%3E%3Cpath d='M15 3h6v6'/%3E%3C%2Fsvg%3E");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6'/%3E%3Cpath d='m21 3-9 9'/%3E%3Cpath d='M15 3h6v6'/%3E%3C%2Fsvg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  vertical-align: -0.1em;
+}
+
 /* Lexical text format: strikethrough (~~text~~) and italic when combined with bold (***text***) */
 .editor-strikethrough {
   text-decoration: line-through;


### PR DESCRIPTION
Closes #160

## Summary

- Render links in blue color with pointer cursor (visually distinct from plain underlined text)
- Add inline link editing popover (triggered by click or Cmd+E): editable URL field, open-in-browser icon button, OK/Cancel icon buttons
- Syntax marker integration: show `[`/`]` brackets when `rich_show_syntax_markers` is ON; show `square-arrow-out-up-right` icon suffix when OFF
- Direct link clicks no longer navigate inside the app — open-in-browser goes via Tauri shell open
- Escape in popover discards changes and closes without triggering Tauri window close

## Changed files

- `src/editor/plugins/LinkPopoverPlugin.tsx` — new plugin implementing link node rendering and popover UI
- `src/editor/MarkdownEditor.tsx` — register LinkPopoverPlugin
- `src/index.css` — link color/cursor styles
- `src-tauri/capabilities/default.json` — add `shell:allow-open` capability for browser open