### PR TITLE
feat: show app icon in About dialog and open GitHub in Help menu

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4126,6 +4126,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "image",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon"] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,8 @@ use commands::{AppState, MenuState, ShortcutState};
 use serde::Serialize;
 use std::sync::Mutex;
 use tauri::{
-    menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
+    image::Image,
+    menu::{AboutMetadata, CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::TrayIconBuilder,
     AppHandle, Emitter, Manager, PhysicalPosition,
 };
@@ -243,7 +244,17 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 "Popmark",
                 true,
                 &[
-                    &PredefinedMenuItem::about(app, None, None)?,
+                    &PredefinedMenuItem::about(
+                        app,
+                        None,
+                        Some(AboutMetadata {
+                            icon: Image::from_bytes(include_bytes!(
+                                "../icons/icon.png"
+                            ))
+                            .ok(),
+                            ..Default::default()
+                        }),
+                    )?,
                     &PredefinedMenuItem::separator(app)?,
                     &menu_settings_item,
                     &PredefinedMenuItem::separator(app)?,
@@ -396,7 +407,10 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             emit_to_main_window(app, "menu-clear-all", ());
         }
         "menu-help" => {
-            // stub: no help documentation yet
+            let _ = tauri_plugin_opener::open_url(
+                "https://github.com/dayflower/popmark",
+                None::<&str>,
+            );
         }
         #[cfg(debug_assertions)]
         "menu-devtools" => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -248,10 +248,7 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                         app,
                         None,
                         Some(AboutMetadata {
-                            icon: Image::from_bytes(include_bytes!(
-                                "../icons/icon.png"
-                            ))
-                            .ok(),
+                            icon: Image::from_bytes(include_bytes!("../icons/icon.png")).ok(),
                             ..Default::default()
                         }),
                     )?,
@@ -407,10 +404,8 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             emit_to_main_window(app, "menu-clear-all", ());
         }
         "menu-help" => {
-            let _ = tauri_plugin_opener::open_url(
-                "https://github.com/dayflower/popmark",
-                None::<&str>,
-            );
+            let _ =
+                tauri_plugin_opener::open_url("https://github.com/dayflower/popmark", None::<&str>);
         }
         #[cfg(debug_assertions)]
         "menu-devtools" => {


### PR DESCRIPTION
## Summary

- Show app icon in the macOS About dialog using `AboutMetadata`
- Open the GitHub repository URL when Help menu is clicked
- Apply rustfmt formatting fixes

## Test plan

- [x] Open About dialog (Apple menu → About Popmark) and verify app icon is shown
- [x] Click Help menu and verify GitHub page opens in browser