### PR TITLE
fix: use correct auto-merge-method parameter for brew-up

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -27,4 +27,4 @@ jobs:
           target-branch: main
           target-repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           publish-mode: pr-auto-merge
-          merge-method: SQUASH
+          auto-merge-method: SQUASH


### PR DESCRIPTION
## Summary

- Fix typo in `.github/workflows/homebrew-tap.yml`: `merge-method` → `auto-merge-method`
- This was introduced in #164 when enabling PR auto-merge for the Homebrew tap workflow