### PR TITLE
fix: use lowercase squash for auto-merge-method in homebrew-tap workflow

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -27,4 +27,4 @@ jobs:
           target-branch: main
           target-repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           publish-mode: pr-auto-merge
-          auto-merge-method: SQUASH
+          auto-merge-method: squash


### PR DESCRIPTION
## Summary

- Change `auto-merge-method: SQUASH` to `auto-merge-method: squash` in `.github/workflows/homebrew-tap.yml`
- The `dayflower/brew-up` action expects lowercase values; uppercase `SQUASH` was silently ignored or caused incorrect behavior (as surfaced in #166)

## Related

- Follows up on #164 (original implementation) and #166 (partial fix)