### PR TITLE
ci: bump brew-up from v0.1.5 to v1.0.0

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Update Homebrew tap
-        uses: dayflower/brew-up@3f2a9919dd8b749fef56f762e911d42df31435d4 # v0.1.5
+        uses: dayflower/brew-up@e248724cf8f143f257d45077dabfee733f338f06 # v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- Bump `dayflower/brew-up` from v0.1.5 to v1.0.0
- Pin commit SHA to `e248724cf8f143f257d45077dabfee733f338f06`

v1.0.0 introduces optional publish template and attribution inputs (`publish-title-template`, `publish-body-template`, `publish-attribution`) but remains fully compatible with the existing workflow configuration.

## Test plan

- [ ] Verify the next release triggers the Homebrew tap update workflow successfully