### PR TITLE
fix: clear all RangeSelection format bits on empty editor

### DIFF
--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -30,9 +30,9 @@ import { EDITOR_NODES } from "./nodes";
 import { CodeEnterPlugin } from "./plugins/CodeEnterPlugin";
 import { CodeExitPlugin } from "./plugins/CodeExitPlugin";
 import { InlineCodeEscapePlugin } from "./plugins/InlineCodeEscapePlugin";
-import { InlineCodeFormatResetPlugin } from "./plugins/InlineCodeFormatResetPlugin";
 import { ListShiftTabExitPlugin } from "./plugins/ListShiftTabExitPlugin";
 import MarkdownLinkPlugin from "./plugins/MarkdownLinkPlugin";
+import { SelectionFormatResetPlugin } from "./plugins/SelectionFormatResetPlugin";
 import { CUSTOM_TRANSFORMERS } from "./transformers";
 
 const initialConfig = {
@@ -486,7 +486,7 @@ export function MarkdownEditor({
               <CodeEnterPlugin />
               <CodeExitPlugin />
               <ListShiftTabExitPlugin />
-              <InlineCodeFormatResetPlugin />
+              <SelectionFormatResetPlugin />
               <InlineCodeEscapePlugin />
             </>
           )}

--- a/src/editor/plugins/SelectionFormatResetPlugin.tsx
+++ b/src/editor/plugins/SelectionFormatResetPlugin.tsx
@@ -10,15 +10,15 @@ import {
 } from "lexical";
 import { useEffect } from "react";
 
-// Prevents IS_CODE from sticking in two scenarios:
+// Prevents stale RangeSelection.format bits in two scenarios:
 // 1. Editor becomes empty: Lexical skips format-reset when root text is empty, so new
-//    input would appear inside a code span with no escape. Clear IS_CODE on every
-//    SELECTION_CHANGE while the editor is empty.
+//    input would carry the previous format (bold, italic, strikethrough, etc.). Clear all
+//    format bits on every SELECTION_CHANGE while the editor is empty.
 // 2. Cursor at right boundary of an IS_CODE TextNode: after MarkdownShortcutPlugin
 //    fires and the user navigates away then back, IS_CODE re-derives from the anchor
 //    node. Clear it when the cursor is at offset === textContentSize and the next
 //    sibling is not also IS_CODE, so the next keypress inserts plain text outside.
-export function InlineCodeFormatResetPlugin() {
+export function SelectionFormatResetPlugin() {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
     return editor.registerCommand(
@@ -27,10 +27,10 @@ export function InlineCodeFormatResetPlugin() {
         const selection = $getSelection();
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
 
-        // Case 1: editor is empty
+        // Case 1: editor is empty — clear all pending format bits
         if ($getRoot().getTextContent() === "") {
-          if (selection.format & IS_CODE) {
-            selection.format &= ~IS_CODE;
+          if (selection.format !== 0) {
+            selection.format = 0;
             selection.dirty = true;
           }
           return false;


### PR DESCRIPTION
## Summary

Fixes #176 — format state (bold, strikethrough, etc.) leaking into a new document after the cursor was inside formatted text.

- Renamed `InlineCodeFormatResetPlugin` → `SelectionFormatResetPlugin` to reflect the broader responsibility
- Extended Case 1 to clear **all** pending format bits (`selection.format = 0`) when the editor is empty, instead of clearing only `IS_CODE`
- Case 2 (cursor at right boundary of an `IS_CODE` node) is `IS_CODE`-specific and unchanged

## Test plan

- [x] Type `**bold**`, place cursor inside it, trigger "New document" → subsequent typing must appear plain (not bold)
- [x] Repeat for italic (`_italic_`) and strikethrough (`~~text~~`)
- [x] Confirm normal bold/italic/strikethrough toggling still works in non-empty documents
- [x] Confirm `IS_CODE` boundary behavior (Case 2) is unaffected — cursor past inline code span should not inherit code format