### PR TITLE
feat: add Show Dock icon toggle in Settings

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -93,7 +93,8 @@ The next time the editor is opened it shows a blank document.
 
 ## 8. App Lifecycle & Menu Bar
 
-- The app runs as a standard application: a Dock icon is visible, and the standard menu bar is available when the editor window is focused. The menu bar provides a File menu (New Document, Export, Show History Folder in Finder, Send to Clipboard), an Edit menu, a Window menu, a Help menu, and access to History and Settings from the app menu. A tray icon also appears in the status bar for quick access.
+- By default, the app runs as a standard application: a Dock icon is visible, and the standard menu bar is available when the editor window is focused. The menu bar provides a File menu (New Document, Export, Show History Folder in Finder, Send to Clipboard), an Edit menu, a Window menu, a Help menu, and access to History and Settings from the app menu. A tray icon also appears in the status bar for quick access.
+- When the "Show Dock icon" setting is disabled, the app hides from the Dock, Cmd+Tab, and the menu bar (macOS Accessory activation policy). The system tray icon and global hotkey remain the access points in this mode.
 - The app starts at login (user-configurable).
 - The app **never quits** unless the user explicitly selects "Quit" from the tray menu or presses Cmd+Q. Closing the editor window hides it; it does not terminate the process.
 - The editor window is hidden by default and appears only when triggered by the global hotkey or via the tray menu.
@@ -118,6 +119,7 @@ The next time the editor is opened it shows a blank document.
 | Plain mode font family | Custom font family for the Plain mode textarea. When empty, the default monospace font is used. |
 | Plain mode font size | Custom font size (in px) for the Plain mode textarea. When empty, the default size is used. |
 | Show syntax markers | When enabled (Rich mode only), displays Markdown syntax markers (`**`, `*`, `~~`, `` ` ``, `#`–`######`) as CSS decorations alongside the formatted text (default: on). |
+| Show Dock icon | When enabled (default), the app appears in the macOS Dock, Cmd+Tab, and menu bar. When disabled, the app is accessible only via the system tray icon and global hotkey (macOS Accessory activation policy). |
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -26,7 +26,7 @@ Popmark is not a file manager or a notes app. It is a fast scratch pad optimized
 
 ## 3. App Lifecycle
 
-- The app runs as a standard application: Dock icon is visible, appears in Cmd+Tab, and the standard menu bar is active when the editor window is focused.
+- By default, the app runs as a standard application: Dock icon is visible, appears in Cmd+Tab, and the standard menu bar is active when the editor window is focused. This is controlled by the `show_dock_icon` setting (default: `true`), which sets the macOS `NSApplicationActivationPolicy` to `Regular`. When `show_dock_icon` is `false`, the policy is set to `Accessory`, hiding the app from the Dock, Cmd+Tab, and the menu bar; the tray icon and global hotkey remain the access points.
 - A tray icon also appears in the status bar for quick access.
 - The process starts at login (user-configurable via Settings).
 - The app never quits unless the user explicitly selects "Quit Popmark" from the tray menu or presses Cmd+Q.
@@ -299,6 +299,7 @@ After the user saves, the backend emits a `settings-changed` event to the main w
 | Max history entries  | 0 (unlimited)      | Maximum number of history entries to retain; oldest are auto-deleted when a new entry exceeds the limit |
 | Notify on copy       | On                 | When enabled, an OS notification is sent after "Send to Clipboard". Stored as `notify_on_copy` in `settings.json`. |
 | Show syntax markers  | On                 | When enabled (Rich mode only), displays Markdown syntax markers as CSS pseudo-elements. Applies the `.show-syntax-markers` class to the `ContentEditable`. Stored as `rich_show_syntax_markers` in `settings.json`. Defaults to `true` when absent. |
+| Show Dock icon       | On                 | When enabled, sets macOS activation policy to `Regular` (Dock + Cmd+Tab + menu bar). When disabled, sets policy to `Accessory` (hidden from Dock, Cmd+Tab, and menu bar; tray and global hotkey remain). Stored as `show_dock_icon` in `settings.json`. Defaults to `true` when absent. Applied at startup and immediately on save. |
 | Rich mode font family | null (browser default) | Custom `font-family` applied to the Rich mode `ContentEditable` via inline style |
 | Rich mode font size  | null (default)     | Custom `font-size` (px) applied to the Rich mode `ContentEditable` via inline style |
 | Plain mode font family | null (browser default) | Custom `font-family` applied to the Plain mode `<textarea>` via inline style |
@@ -319,11 +320,12 @@ After the user saves, the backend emits a `settings-changed` event to the main w
   "plain_font_size": null,
   "send_shortcut": "super+enter",
   "notify_on_copy": true,
-  "rich_show_syntax_markers": true
+  "rich_show_syntax_markers": true,
+  "show_dock_icon": true
 }
 ```
 
-All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`). `rich_show_syntax_markers` defaults to `true` when absent (`#[serde(default = "default_rich_show_syntax_markers")]`).
+All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`). `rich_show_syntax_markers` defaults to `true` when absent (`#[serde(default = "default_rich_show_syntax_markers")]`). `show_dock_icon` defaults to `true` when absent (`#[serde(default = "default_show_dock_icon")]`).
 
 ---
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,5 +27,5 @@ font-enumeration = "0.9.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-foundation = "0.3"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder"] }
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder", "NSRunningApplication", "NSImage"] }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -63,6 +63,8 @@ pub struct Settings {
     pub notify_on_copy: bool,
     #[serde(default = "default_rich_show_syntax_markers")]
     pub rich_show_syntax_markers: bool,
+    #[serde(default = "default_show_dock_icon")]
+    pub show_dock_icon: bool,
 }
 
 const DEFAULT_EDITOR_MODE: &str = "rich";
@@ -70,6 +72,7 @@ const DEFAULT_SEND_SHORTCUT: &str = "super+enter";
 const DEFAULT_FONT_FALLBACK: bool = true;
 const DEFAULT_NOTIFY_ON_COPY: bool = true;
 const DEFAULT_RICH_SHOW_SYNTAX_MARKERS: bool = true;
+const DEFAULT_SHOW_DOCK_ICON: bool = true;
 
 fn default_editor_mode() -> String {
     DEFAULT_EDITOR_MODE.to_string()
@@ -91,6 +94,10 @@ fn default_rich_show_syntax_markers() -> bool {
     DEFAULT_RICH_SHOW_SYNTAX_MARKERS
 }
 
+fn default_show_dock_icon() -> bool {
+    DEFAULT_SHOW_DOCK_ICON
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Settings {
@@ -108,6 +115,7 @@ impl Default for Settings {
             send_shortcut: DEFAULT_SEND_SHORTCUT.to_string(),
             notify_on_copy: DEFAULT_NOTIFY_ON_COPY,
             rich_show_syntax_markers: DEFAULT_RICH_SHOW_SYNTAX_MARKERS,
+            show_dock_icon: DEFAULT_SHOW_DOCK_ICON,
         }
     }
 }
@@ -258,6 +266,32 @@ pub fn re_register_shortcut(app: &AppHandle, hotkey: &str) -> Result<(), String>
 }
 
 // ---------------------------------------------------------------------------
+// Dock icon policy
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+pub fn apply_dock_icon_policy(show: bool) {
+    use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+    use objc2_foundation::MainThreadMarker;
+    unsafe {
+        let mtm = MainThreadMarker::new_unchecked();
+        let ns_app = NSApplication::sharedApplication(mtm);
+        let policy = if show {
+            NSApplicationActivationPolicy::Regular
+        } else {
+            NSApplicationActivationPolicy::Accessory
+        };
+        let _ = ns_app.setActivationPolicy(policy);
+        // Re-set the app icon after restoring Dock visibility; without this,
+        // macOS shows a generic "exec" terminal icon instead of the bundle icon.
+        if show {
+            let icon = ns_app.applicationIconImage();
+            ns_app.setApplicationIconImage(icon.as_deref());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // IPC commands: settings
 // ---------------------------------------------------------------------------
 
@@ -283,6 +317,16 @@ pub fn save_settings(app: AppHandle, mut settings: Settings) -> Result<(), Strin
         app.autolaunch().enable().map_err(|e| e.to_string())?;
     } else {
         app.autolaunch().disable().map_err(|e| e.to_string())?;
+    }
+
+    // Apply Dock icon visibility
+    #[cfg(target_os = "macos")]
+    {
+        let show = settings.show_dock_icon;
+        app.run_on_main_thread(move || {
+            apply_dock_icon_policy(show);
+        })
+        .map_err(|e| e.to_string())?;
     }
 
     // Notify main window that settings changed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,11 +43,11 @@ pub fn run() {
 
             setup_tray(handle)?;
 
-            // Read saved hotkey from settings and register global shortcut
-            let hotkey = commands::get_settings(handle.clone())
-                .unwrap_or_default()
-                .hotkey;
-            commands::re_register_shortcut(handle, &hotkey)?;
+            // Read saved settings and register global shortcut
+            let settings = commands::get_settings(handle.clone()).unwrap_or_default();
+            commands::re_register_shortcut(handle, &settings.hotkey)?;
+            #[cfg(target_os = "macos")]
+            commands::apply_dock_icon_policy(settings.show_dock_icon);
 
             Ok(())
         })

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -63,6 +63,7 @@ export function SettingsPanel() {
   const [capturedSendShortcut, setCapturedSendShortcut] = useState("super+enter");
   const [isCapturingSend, setIsCapturingSend] = useState(false);
   const [launchAtLogin, setLaunchAtLogin] = useState(false);
+  const [showDockIcon, setShowDockIcon] = useState<boolean>(true);
   const [copyAsRichText, setCopyAsRichText] = useState(false);
   const [notifyOnCopy, setNotifyOnCopy] = useState<boolean>(true);
   const [richShowSyntaxMarkers, setRichShowSyntaxMarkers] = useState<boolean>(true);
@@ -77,6 +78,7 @@ export function SettingsPanel() {
         setSavedHotkey(s.hotkey);
         setCapturedHotkey(s.hotkey);
         setLaunchAtLogin(s.launch_at_login);
+        setShowDockIcon(s.show_dock_icon ?? true);
         setCopyAsRichText(s.copy_as_rich_text);
         setNotifyOnCopy(s.notify_on_copy ?? true);
         setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
@@ -137,6 +139,7 @@ export function SettingsPanel() {
       settings: {
         hotkey: capturedHotkey,
         launch_at_login: launchAtLogin,
+        show_dock_icon: showDockIcon,
         copy_as_rich_text: copyAsRichText,
         max_history_entries:
           maxHistoryEntries.trim() !== "" && parsedLimit > 0 ? parsedLimit : null,
@@ -205,6 +208,14 @@ export function SettingsPanel() {
           checked={launchAtLogin}
           onChange={setLaunchAtLogin}
           label="Launch at login"
+          className="mb-3"
+        />
+
+        {/* Show Dock icon */}
+        <CheckboxSetting
+          checked={showDockIcon}
+          onChange={setShowDockIcon}
+          label="Show Dock icon"
           className="mb-3"
         />
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -15,4 +15,5 @@ export interface Settings {
   send_shortcut?: string;
   notify_on_copy?: boolean;
   rich_show_syntax_markers?: boolean;
+  show_dock_icon?: boolean;
 }


### PR DESCRIPTION
Closes #181

## Summary

- Adds `show_dock_icon` boolean setting (default: `true`) to control macOS Dock visibility
- When disabled, switches `NSApplicationActivationPolicy` to `Accessory` — hides the app from the Dock, Cmd+Tab, and menu bar; tray icon and global hotkey remain accessible
- Re-applies the policy at startup and immediately on Settings save (via `run_on_main_thread`)
- Fixes a macOS quirk where re-enabling the Dock icon would show a generic "exec" terminal icon by re-setting `applicationIconImage` after restoring `Regular` policy

## Test plan

- [x] Fresh launch (no `settings.json`) → Dock icon visible (default `true`)
- [x] Open Settings → "Show Dock icon" checkbox is checked
- [x] Uncheck → Save → Dock icon disappears immediately; tray icon and global hotkey still work
- [x] Re-open Settings via tray → checkbox is unchecked
- [x] Re-check → Save → Dock icon reappears immediately with the correct bundle icon (not "exec")
- [x] Restart with `show_dock_icon: false` in `settings.json` → Dock icon absent from startup
- [x] Old `settings.json` without the key → deserializes as `true` (backward compatible)