### PR TITLE
feat: add Export button to toolbar

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -85,9 +85,9 @@ The next time the editor is opened it shows a blank document.
 
 ## 7. Export
 
-- Users can save the current editor content as a `.md` file via a native save dialog (File menu, ⌘S).
+- Users can save the current editor content as a `.md` file via a native save dialog (toolbar button, File menu, or ⌘S).
 - Export does not clear the draft and does not add an entry to history.
-- Export is an optional convenience; it is not the primary workflow. There is no Export button in the toolbar.
+- Export is an optional convenience; it is not the primary workflow.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -99,9 +99,10 @@ A minimal toolbar appears at the top of the editor window:
 |-------------------|-------------------------------|
 | History           | Open/close the history panel (leftmost; shows pressed state when panel is open) |
 | New               | Auto-save draft to history (if non-empty), clear draft, start new document |
+| Export            | Save the current editor content as a `.md` file via a native save dialog (**⌘S**); same behavior as the File menu Export item |
 | Rich / Plain      | Dual-button toggle group at the far right: clicking the inactive button switches the editor mode (**⌘⇧R** for Rich, **⌘⇧P** for Plain); clicking the already-active button is a no-op |
 
-Buttons are icon-only (lucide-react icons). The Rich/Plain toggle group uses text labels. Export is not available in the toolbar; it is accessible via the File menu (⌘S).
+Buttons are icon-only (lucide-react icons). The Rich/Plain toggle group uses text labels. Export is also accessible via the File menu (⌘S).
 
 ### 6.4 Send to Clipboard Button
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,8 +1,9 @@
-import { FilePlus, PanelLeft, SquareMenu, SquarePilcrow } from "lucide-react";
+import { FilePlus, PanelLeft, Save, SquareMenu, SquarePilcrow } from "lucide-react";
 
 interface ToolbarProps {
   isHistoryOpen: boolean;
   onNew: () => void;
+  onExport: () => void;
   onToggleHistory: () => void;
   editorMode: "rich" | "plain";
   onModeToggle: () => void;
@@ -11,6 +12,7 @@ interface ToolbarProps {
 export function Toolbar({
   isHistoryOpen,
   onNew,
+  onExport,
   onToggleHistory,
   editorMode,
   onModeToggle,
@@ -33,6 +35,7 @@ export function Toolbar({
       >
         <PanelLeft size={16} />
       </button>
+      <div className="relative top-px w-px h-5 bg-gray-300 dark:bg-gray-600" />
       <button
         type="button"
         onClick={onNew}
@@ -40,6 +43,14 @@ export function Toolbar({
         title="New document (⌘N)"
       >
         <FilePlus size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={onExport}
+        className="p-1.5 text-gray-600 dark:text-gray-400 rounded hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700 cursor-default"
+        title="Export (⌘S)"
+      >
+        <Save size={16} />
       </button>
       <div
         data-tauri-drag-region

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -70,6 +70,7 @@ interface EditorPluginsProps {
   plainContent: string;
   setPlainContent: (c: string) => void;
   modeToggleFnRef: React.MutableRefObject<(() => void) | null>;
+  exportFnRef: React.MutableRefObject<(() => void) | null>;
   onFocusPlain: () => void;
   copyAsRichText: boolean;
   setCopyAsRichText: (v: boolean) => void;
@@ -93,6 +94,7 @@ function EditorPlugins({
   plainContent,
   setPlainContent,
   modeToggleFnRef,
+  exportFnRef,
   onFocusPlain,
   copyAsRichText,
   setCopyAsRichText,
@@ -153,6 +155,17 @@ function EditorPlugins({
     }
   }, [editor, editorMode, textareaRef]);
 
+  const handleExport = useCallback(() => {
+    if (editorMode === "plain") {
+      invoke("export_file", { content: plainContent, defaultName: "note.md" });
+    } else {
+      editor.getEditorState().read(() => {
+        const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
+        invoke("export_file", { content, defaultName: "note.md" });
+      });
+    }
+  }, [editor, editorMode, plainContent]);
+
   useMenuEventListeners({
     editorMode,
     plainContent,
@@ -163,15 +176,20 @@ function EditorPlugins({
     onToggleHistory,
     onClearHistory,
     onNew,
+    onExport: handleExport,
     onPastePlainText,
     handleModeToggle,
     handleClearAll,
   });
 
-  // Keep the ref in sync so Toolbar and textarea keydown can call it
+  // Keep the refs in sync so Toolbar and textarea keydown can call them
   useEffect(() => {
     modeToggleFnRef.current = handleModeToggle;
   }, [handleModeToggle, modeToggleFnRef]);
+
+  useEffect(() => {
+    exportFnRef.current = handleExport;
+  }, [handleExport, exportFnRef]);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -294,6 +312,7 @@ export function MarkdownEditor({
   const [sendShortcut, setSendShortcut] = useState("super+enter");
   const { entries, loading, loadHistory, getEntry, deleteEntry, clearHistory } = useHistory();
   const modeToggleFnRef = useRef<(() => void) | null>(null);
+  const exportFnRef = useRef<(() => void) | null>(null);
   const plainDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const editorRef = useRef<LexicalEditor | null>(null);
@@ -434,6 +453,7 @@ export function MarkdownEditor({
       <Toolbar
         isHistoryOpen={isHistoryOpen}
         onNew={handleNew}
+        onExport={() => exportFnRef.current?.()}
         onToggleHistory={() => setIsHistoryOpen((v) => !v)}
         editorMode={editorMode}
         onModeToggle={() => modeToggleFnRef.current?.()}
@@ -504,6 +524,7 @@ export function MarkdownEditor({
             plainContent={plainContent}
             setPlainContent={setPlainContent}
             modeToggleFnRef={modeToggleFnRef}
+            exportFnRef={exportFnRef}
             onFocusPlain={handleFocusPlain}
             copyAsRichText={copyAsRichText}
             setCopyAsRichText={setCopyAsRichText}

--- a/src/hooks/useMenuEventListeners.ts
+++ b/src/hooks/useMenuEventListeners.ts
@@ -1,4 +1,4 @@
-import { $convertFromMarkdownString, $convertToMarkdownString } from "@lexical/markdown";
+import { $convertFromMarkdownString } from "@lexical/markdown";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { invoke } from "@tauri-apps/api/core";
 import {
@@ -24,6 +24,7 @@ interface UseMenuEventListenersOptions {
   onToggleHistory: () => void;
   onClearHistory: () => void;
   onNew: () => void;
+  onExport: () => void;
   onPastePlainText: (text: string) => void;
   handleModeToggle: () => void;
   handleClearAll: () => void;
@@ -39,6 +40,7 @@ export function useMenuEventListeners({
   onToggleHistory,
   onClearHistory,
   onNew,
+  onExport,
   onPastePlainText,
   handleModeToggle,
   handleClearAll,
@@ -55,16 +57,7 @@ export function useMenuEventListeners({
 
   useMenuEvent("menu-clear-all", handleClearAll, [handleClearAll]);
 
-  useMenuEvent("menu-export", () => {
-    if (editorMode === "plain") {
-      invoke("export_file", { content: plainContent, defaultName: "note.md" });
-    } else {
-      editor.getEditorState().read(() => {
-        const content = $convertToMarkdownString(CUSTOM_TRANSFORMERS);
-        invoke("export_file", { content, defaultName: "note.md" });
-      });
-    }
-  }, [editor, editorMode, plainContent]);
+  useMenuEvent("menu-export", onExport, [onExport]);
 
   useMenuEvent("menu-send-to-clipboard", copyToClipboard, [copyToClipboard]);
 


### PR DESCRIPTION
## Summary

Adds an Export button to the editor toolbar so users can save the current content as a `.md` file without going through the File menu.

- New **Export** button (lucide `Save` icon) placed next to **New**, triggering the existing `export_file` IPC / save dialog. Wired through an `exportFnRef`, mirroring the existing `modeToggleFnRef` pattern.
- Refactored the `menu-export` listener in `useMenuEventListeners` to share a single `handleExport` (no duplicated logic between menu and toolbar).
- Added a thin vertical divider between **History** and **New** in the toolbar.
- Updated `docs/REQUIREMENTS.md` and `docs/SPEC.md`, which previously stated there was no Export button in the toolbar.

## Notes

- Export behavior is unchanged: it does not clear the draft and does not add a history entry. The File menu item (⌘S) continues to work.

## Test plan

- [x] `npm run check` (Biome + clippy)
- [x] `npm run build` (tsc + vite)
- [x] Manual: Export button opens save dialog in both rich and plain modes; File menu ⌘S still works