### PR TITLE
chore: bump window-vibrancy from 0.6 to 0.7.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2884,7 +2884,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
- "window-vibrancy",
+ "window-vibrancy 0.7.1",
 ]
 
 [[package]]
@@ -3815,7 +3815,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "window-vibrancy",
+ "window-vibrancy 0.6.0",
  "windows",
 ]
 
@@ -5060,6 +5060,21 @@ dependencies = [
  "objc2-foundation",
  "raw-window-handle",
  "windows-sys 0.59.0",
+ "windows-version",
+]
+
+[[package]]
+name = "window-vibrancy"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010797bd7c40396fbc59d3105089fed0885fe267a0ef4a0a4646df54e28647f6"
+dependencies = [
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "windows-sys 0.60.2",
  "windows-version",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,4 +29,4 @@ font-enumeration = "0.9.0"
 objc2-foundation = "0.3"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder", "NSRunningApplication", "NSImage"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
-window-vibrancy = "0.6"
+window-vibrancy = "0.7"


### PR DESCRIPTION
## Summary

Bumps `window-vibrancy` from `0.6` to `0.7.1` (as suggested by Dependabot).

## Findings from verification

### Build & API compatibility
- Our only usage is the direct `window_vibrancy::apply_vibrancy(...)` call in `src-tauri/src/lib.rs` (`NSVisualEffectMaterial::HeaderView` / `NSVisualEffectState::Active`).
- The API is unchanged between 0.6 and 0.7.1, so no source changes were needed.
- `cargo build` completes successfully.

### Two versions coexist in the dependency tree
After this bump, the lockfile contains **both** versions:

```
window-vibrancy v0.6.0  <- required by tauri 2.11.2 (pinned to "0.6")
window-vibrancy v0.7.1  <- popmark (this crate)
```

`tauri 2.11.2` declares `window-vibrancy = "0.6"` (i.e. `>=0.6.0, <0.7.0`), so it stays on 0.6.0 regardless of our bump. The duplicate cannot be removed until tauri itself moves to 0.7. This is harmless (slightly larger binary / build), not a conflict.

### Which version actually runs at runtime: **0.7.1**
- popmark applies vibrancy via the direct `apply_vibrancy` call → **0.7.1**.
- tauri's internal vibrancy module (`tauri/src/vibrancy/macos.rs`) uses **0.6.0**, but that path is only invoked when using tauri's `windowEffects` feature (`tauri.conf.json` window effects or `WebviewWindowBuilder::effects()`).
- popmark configures neither, so the 0.6.0 path is **never executed** — it is compiled-in dead code.

Conclusion: the vibrancy actually applied to the window is fully driven by 0.7.1.

## Test plan
- [x] `cargo build` succeeds