### PR TITLE
feat: move copy format toggle to Send to Clipboard split button

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -39,15 +39,24 @@ Popmark is an application with a tray icon and standard menu bar, providing a qu
 
 ## 5. Send to Clipboard
 
-Triggered by the "Send to clipboard" button anchored to the bottom-right of the editor pane (also available via keyboard shortcut — configurable in Settings, default `⌘↵`):
+Triggered by the "Send to Clipboard" split button anchored to the bottom-right of the editor pane (also available via keyboard shortcut — configurable in Settings, default `⌘↵`):
 
-1. Current editor content is serialized to plain Markdown and written to the system clipboard. If "Copy as Rich Text" is enabled in Settings (Rich mode only), the content is also written as HTML so that rich formatting is preserved when pasting into applications that support it.
+1. Current editor content is serialized to plain Markdown and written to the system clipboard. If the copy format is set to **Rich Text** (Rich mode only), the content is also written as HTML so that rich formatting is preserved when pasting into applications that support it.
 2. If the content is non-empty, the document is saved to history with a timestamp.
 3. The draft is cleared.
 4. The editor window is hidden.
 5. An OS notification ("Copied to clipboard") is sent as a brief confirmation, if "Notify on copy" is enabled in Settings (default: on). Requires notification permission (one-time system prompt); silenced during Focus / Do Not Disturb.
 
 The next time the editor is opened it shows a blank document.
+
+### Copy format (Rich Text / Markdown)
+
+The copy format is chosen directly at the point of copying rather than buried in Settings:
+
+- The "Send to Clipboard" button is a **split button** (like GitHub's merge button). Its ▾ dropdown lets you pick **Rich text** or **Markdown**; the main button label reflects the current choice ("Send Rich Text to Clipboard" / "Send Markdown to Clipboard").
+- The same toggle is available from the **Copy Format** submenu in the app menu bar and the tray (status bar) icon menu, and via the **`⌘⇧M`** keyboard shortcut.
+- The chosen format is persisted across launches.
+- **Plain mode always copies Markdown.** While in Plain mode the format is forced to Markdown and the toggle is disabled; switching back to Rich mode restores the previously selected format.
 
 ---
 
@@ -93,7 +102,7 @@ The next time the editor is opened it shows a blank document.
 
 ## 8. App Lifecycle & Menu Bar
 
-- By default, the app runs as a standard application: a Dock icon is visible, and the standard menu bar is available when the editor window is focused. The menu bar provides a File menu (New Document, Export, Show History Folder in Finder, Send to Clipboard), an Edit menu, a Window menu, a Help menu, and access to History and Settings from the app menu. A tray icon also appears in the status bar for quick access.
+- By default, the app runs as a standard application: a Dock icon is visible, and the standard menu bar is available when the editor window is focused. The menu bar provides a File menu (New Document, Export, Show History Folder in Finder, Send to Clipboard, Copy Format), an Edit menu, a Window menu, a Help menu, and access to History and Settings from the app menu. A tray icon also appears in the status bar for quick access (including the Copy Format toggle).
 - When the "Show Dock icon" setting is disabled, the app hides from the Dock, Cmd+Tab, and the menu bar (macOS Accessory activation policy). The system tray icon and global hotkey remain the access points in this mode.
 - The app starts at login (user-configurable).
 - The app **never quits** unless the user explicitly selects "Quit" from the tray menu or presses Cmd+Q. Closing the editor window hides it; it does not terminate the process.
@@ -112,7 +121,6 @@ The next time the editor is opened it shows a blank document.
 | Send to Clipboard shortcut | Key combination to trigger "Send to Clipboard" from inside the editor (default: `⌘↵`). Configurable independently from the global hotkey. |
 | Launch at login | Whether the app starts automatically when the user logs in |
 | Editor mode | Whether the editor opens in **Rich** (source-visible WYSIWYG) or **Plain** (raw Markdown textarea) mode |
-| Copy as Rich Text | When enabled (Rich mode only), "Send to Clipboard" copies the content as both HTML (rich text) and plain Markdown, preserving formatting in apps that support rich paste |
 | Max history entries | Maximum number of history entries to retain. Empty or 0 means unlimited. When a new entry is saved and the count exceeds the limit, the oldest entries are deleted automatically. |
 | Rich mode font family | Custom font family for the Rich mode editor. When empty, the browser default is used. |
 | Rich mode font size | Custom font size (in px) for the Rich mode editor. When empty, the default size is used. |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -115,11 +115,14 @@ Buttons are icon-only (lucide-react icons). The Rich/Plain toggle group uses tex
 
 ### 6.4 Send to Clipboard Button
 
-A prominent primary-action button sits in the **footer bar at the bottom of the editor pane**. It is a presentational component (`SendToClipboardButton`) that receives an `onSend` callback and the `sendShortcut`, decoupled from the editor internals:
+A prominent primary-action **split button** sits in the **footer bar at the bottom of the editor pane**. It is a presentational component (`SendToClipboardButton`) that receives `onSend`, `sendShortcut`, `copyAsRichText`, `editorMode`, and `onSetCopyFormat`, decoupled from the editor internals:
 
-- **Label:** `Send to clipboard (⌘↵)` — the shortcut hint is rendered dynamically using `formatHotkey(sendShortcut)` from the current `send_shortcut` setting
-- **Style:** `bg-blue-500 text-white rounded hover:bg-blue-600 active:bg-blue-700 px-3 py-1.5 text-sm`
-- **Behavior:** same as the configured keyboard shortcut (default `⌘Return`) — copy Markdown (and optionally HTML) to clipboard, save to history, clear draft, hide window
+- **Layout:** a main button plus a ▾ dropdown (GitHub merge-button style). The dropdown lists **Rich text** / **Markdown** as a radio-style choice with a check on the current format; selecting one calls `onSetCopyFormat(rich)`.
+- **Label:** reflects the current format — `Send Rich Text to Clipboard (⌘↵)` or `Send Markdown to Clipboard (⌘↵)`. The shortcut hint is rendered dynamically via `formatHotkey(sendShortcut)`.
+- **Style:** `bg-blue-500 text-white` split into `rounded-l` (main) and `rounded-r` (dropdown) segments.
+- **Behavior:** the main button performs the copy in the current format (copy Markdown, and HTML too when Rich Text) — save to history, clear draft, hide window.
+- **Plain mode:** the format is forced to Markdown; the ▾ dropdown is disabled. Switching back to Rich mode restores the previously selected format (the saved `copy_as_rich_text` preference is preserved untouched while in Plain mode).
+- The format can also be changed from the **Copy Format** submenu (app menu + tray) and the `⌘⇧M` shortcut; all surfaces stay in sync via `set_copy_format_menu`.
 
 ---
 
@@ -142,8 +145,8 @@ Triggered by the "Send to clipboard" button anchored to the bottom-right of the 
 
 **Steps executed in order:**
 
-1. Read the current Markdown from the live editor (`$convertToMarkdownString`). If "Copy as Rich Text" is enabled in Settings (Rich mode only), generate clean semantic HTML from that Markdown via a throwaway editor seeded with the **standard** Lexical nodes and `@lexical/html` (`src/editor/markdownToHtml.ts`). HTML is derived from the Markdown — not from the live editor's source-visible custom nodes — so links/code/lists export as proper `<a>` / `<pre>` / `<ul>` rather than raw Markdown markers.
-2. Write the Markdown text to the system clipboard. If "Copy as Rich Text" is enabled, write both HTML and plain Markdown via `write_html(html, fallback_text)` so that apps supporting rich paste receive formatted content.
+1. Read the current Markdown from the live editor (`$convertToMarkdownString`). If the copy format is **Rich Text** (`copy_as_rich_text` true and Rich mode), generate clean semantic HTML from that Markdown via a throwaway editor seeded with the **standard** Lexical nodes and `@lexical/html` (`src/editor/markdownToHtml.ts`). HTML is derived from the Markdown — not from the live editor's source-visible custom nodes — so links/code/lists export as proper `<a>` / `<pre>` / `<ul>` rather than raw Markdown markers.
+2. Write the Markdown text to the system clipboard. If the format is Rich Text, write both HTML and plain Markdown via `write_html(html, fallback_text)` so that apps supporting rich paste receive formatted content.
 3. Save the document to history with the current timestamp (skipped if the content is empty or whitespace-only).
 4. Clear `draft.md` (reset to empty).
 5. Hide the editor window.
@@ -212,6 +215,10 @@ A small icon in the status bar provides a dropdown menu for quick access:
 | History…           | Show the editor window with history open   |
 | Settings…          | Open settings panel                        |
 | —                  | Separator                                  |
+| Copy Format ▶      | Submenu to select the copy format          |
+| — Rich text        | Set copy format to Rich Text (checkmark = active; disabled in Plain mode) |
+| — Markdown         | Set copy format to Markdown (checkmark = active) |
+| —                  | Separator                                  |
 | Quit Popmark       | Terminate the app                          |
 
 ---
@@ -240,6 +247,11 @@ The standard menu bar is active when the editor window is focused. It provides:
 | Show History Folder in Finder |          | Open the history directory in Finder / system file manager |
 | —                           |          | Separator                     |
 | Send to Clipboard           | (configurable, default ⌘↵) | Copy to clipboard, save to history, clear draft, hide window |
+| Copy Format ▶               |          | Submenu to select the copy format                  |
+| — Rich text                 | ⌘⇧M      | Set copy format to Rich Text (checkmark = active; disabled in Plain mode) |
+| — Markdown                  |          | Set copy format to Markdown (checkmark = active; disabled in Plain mode) |
+
+`⌘⇧M` toggles between Rich Text and Markdown (only effective in Rich mode; Plain mode is forced to Markdown).
 
 **View menu**
 
@@ -303,7 +315,6 @@ After the user saves, the backend emits a `settings-changed` event to the main w
 | Send to Clipboard shortcut | `⌘↵` (`super+enter`) | Key combination to trigger "Send to Clipboard" from inside the editor. Captured via the Settings UI; stored as `send_shortcut` in `settings.json`. This is a window-local shortcut (not a system-level global shortcut). |
 | Launch at login      | Off                | Register as a login item              |
 | Editor mode          | `rich`             | `rich` = source-visible WYSIWYG; `plain` = raw Markdown textarea |
-| Copy as Rich Text    | Off                | When enabled (Rich mode only), "Send to Clipboard" copies HTML + plain Markdown so rich formatting is preserved in apps that support it |
 | Max history entries  | 0 (unlimited)      | Maximum number of history entries to retain; oldest are auto-deleted when a new entry exceeds the limit |
 | Notify on copy       | On                 | When enabled, an OS notification is sent after "Send to Clipboard". Stored as `notify_on_copy` in `settings.json`. |
 | Show syntax markers  | On                 | When enabled (Rich mode only), displays Markdown syntax markers as CSS pseudo-elements. Applies the `.show-syntax-markers` class to the `ContentEditable`. Stored as `rich_show_syntax_markers` in `settings.json`. Defaults to `true` when absent. |
@@ -312,6 +323,8 @@ After the user saves, the backend emits a `settings-changed` event to the main w
 | Rich mode font size  | null (default)     | Custom `font-size` (px) applied to the Rich mode `ContentEditable` via inline style |
 | Plain mode font family | null (browser default) | Custom `font-family` applied to the Plain mode `<textarea>` via inline style |
 | Plain mode font size | null (default)     | Custom `font-size` (px) applied to the Plain mode `<textarea>` via inline style |
+
+The copy format preference (`copy_as_rich_text`) is **not** part of the Settings UI. It is still persisted in `settings.json` but is managed from the "Send to Clipboard" split button, the Copy Format menus, and `⌘⇧M` (via `save_copy_as_rich_text`). Like `editor_mode`, `save_settings` preserves the on-disk value so saving the Settings panel never clobbers the chosen format.
 
 ### 12.1 settings.json Schema
 
@@ -362,7 +375,7 @@ All files are managed by the Tauri backend (Rust). The frontend never accesses t
 |--------------------------|-----------------|----------------------------------------------|
 | `get_draft`              | Rust → React    | Load current draft content on window open    |
 | `save_draft`             | React → Rust    | Persist draft (debounced auto-save)          |
-| `copy_to_clipboard`      | React → Rust    | Copy to clipboard (plain Markdown + optional HTML when Copy as Rich Text is enabled), save history, clear draft |
+| `copy_to_clipboard`      | React → Rust    | Copy to clipboard (plain Markdown + optional HTML when the Rich Text format is selected), save history, clear draft |
 | `read_clipboard_text`    | React → Rust    | Read plain text from clipboard (used by Paste and Match Style) |
 | `list_history`           | Rust → React    | Return history index entries                 |
 | `get_history_entry`      | Rust → React    | Return content of a specific history file    |
@@ -371,7 +384,9 @@ All files are managed by the Tauri backend (Rust). The frontend never accesses t
 | `save_settings`          | React → Rust    | Persist settings changes; emits `settings-changed` event to the main window |
 | `new_document`           | React → Rust    | Auto-save current draft to history (if non-empty), then clear draft |
 | `save_editor_mode`       | React → Rust    | Persist the selected editor mode (`rich` or `plain`) to settings.json |
+| `save_copy_as_rich_text` | React → Rust    | Persist the copy format preference (`copy_as_rich_text`) to settings.json |
 | `set_editor_mode_menu`   | React → Rust    | Sync the View > Editor Mode submenu checkmarks to the current mode |
+| `set_copy_format_menu`   | React → Rust    | Sync the Copy Format submenu (app menu + tray) checkmarks and enabled state; Plain mode forces Markdown and disables the items |
 | `show_settings_window`   | React → Rust    | Show the settings window and unregister the global shortcut |
 | `hide_settings_window`   | React → Rust    | Hide the settings window and re-register the global shortcut |
 | `set_hotkey_capture_active` | React → Rust | Unregister (active=true) or re-register (active=false) the global shortcut during hotkey capture |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,6 +18,10 @@ pub struct MenuState {
     pub history_item: Option<CheckMenuItem<tauri::Wry>>,
     pub editor_mode_rich: Option<CheckMenuItem<tauri::Wry>>,
     pub editor_mode_plain: Option<CheckMenuItem<tauri::Wry>>,
+    pub copy_format_rich: Option<CheckMenuItem<tauri::Wry>>,
+    pub copy_format_markdown: Option<CheckMenuItem<tauri::Wry>>,
+    pub tray_copy_format_rich: Option<CheckMenuItem<tauri::Wry>>,
+    pub tray_copy_format_markdown: Option<CheckMenuItem<tauri::Wry>>,
     pub recall_last: Option<MenuItem<tauri::Wry>>,
 }
 
@@ -302,9 +306,11 @@ pub fn get_settings(app: AppHandle) -> Result<Settings, String> {
 
 #[tauri::command]
 pub fn save_settings(app: AppHandle, mut settings: Settings) -> Result<(), String> {
-    // Preserve the current editor_mode — managed exclusively via save_editor_mode
+    // Preserve fields managed outside the settings panel: editor_mode
+    // (save_editor_mode) and copy_as_rich_text (save_copy_as_rich_text).
     if let Ok(current) = load_settings_from_disk(&app) {
         settings.editor_mode = current.editor_mode;
+        settings.copy_as_rich_text = current.copy_as_rich_text;
     }
     save_settings_to_disk(&app, &settings)?;
 
@@ -350,6 +356,13 @@ pub fn list_fonts() -> Result<Vec<String>, String> {
 pub fn save_editor_mode(app: AppHandle, mode: String) -> Result<(), String> {
     let mut settings = load_settings_from_disk(&app)?;
     settings.editor_mode = mode;
+    save_settings_to_disk(&app, &settings)
+}
+
+#[tauri::command]
+pub fn save_copy_as_rich_text(app: AppHandle, value: bool) -> Result<(), String> {
+    let mut settings = load_settings_from_disk(&app)?;
+    settings.copy_as_rich_text = value;
     save_settings_to_disk(&app, &settings)
 }
 
@@ -593,6 +606,27 @@ pub fn set_editor_mode_menu(state: tauri::State<'_, AppState>, mode: String) {
     }
     if let Some(item) = menu.editor_mode_plain.as_ref() {
         let _ = item.set_checked(!is_rich);
+    }
+}
+
+#[tauri::command]
+pub fn set_copy_format_menu(state: tauri::State<'_, AppState>, rich: bool, enabled: bool) {
+    // In plain mode (enabled == false) the copy format is forced to markdown,
+    // so reflect markdown as checked and disable both items.
+    let show_rich = rich && enabled;
+    let menu = state.menu.lock().expect("mutex poisoned: menu");
+    for (rich_item, md_item) in [
+        (&menu.copy_format_rich, &menu.copy_format_markdown),
+        (&menu.tray_copy_format_rich, &menu.tray_copy_format_markdown),
+    ] {
+        if let Some(item) = rich_item.as_ref() {
+            let _ = item.set_checked(show_rich);
+            let _ = item.set_enabled(enabled);
+        }
+        if let Some(item) = md_item.as_ref() {
+            let _ = item.set_checked(!show_rich);
+            let _ = item.set_enabled(enabled);
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,10 @@ pub fn run() {
                 history_item: None,
                 editor_mode_rich: None,
                 editor_mode_plain: None,
+                copy_format_rich: None,
+                copy_format_markdown: None,
+                tray_copy_format_rich: None,
+                tray_copy_format_markdown: None,
                 recall_last: None,
             }),
         })
@@ -79,9 +83,11 @@ pub fn run() {
             commands::get_settings,
             commands::save_settings,
             commands::save_editor_mode,
+            commands::save_copy_as_rich_text,
             commands::list_fonts,
             commands::set_history_panel_open,
             commands::set_editor_mode_menu,
+            commands::set_copy_format_menu,
             commands::show_settings_window,
             commands::hide_settings_window,
             commands::set_hotkey_capture_active,
@@ -137,10 +143,11 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         false,
         Some("cmd+h"),
     )?;
-    let saved_mode = commands::get_settings(app.clone())
-        .unwrap_or_default()
-        .editor_mode;
-    let is_rich = saved_mode != "plain";
+    let saved_settings = commands::get_settings(app.clone()).unwrap_or_default();
+    let is_rich = saved_settings.editor_mode != "plain";
+    // Copy format is forced to markdown in plain mode; only reflect the saved
+    // rich preference when actually in rich mode.
+    let copy_as_rich = saved_settings.copy_as_rich_text && is_rich;
     let menu_editor_mode_rich_item = CheckMenuItem::with_id(
         app,
         "menu-set-editor-mode-rich",
@@ -162,6 +169,28 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         "Editor Mode",
         true,
         &[&menu_editor_mode_rich_item, &menu_editor_mode_plain_item],
+    )?;
+    let menu_copy_format_rich_item = CheckMenuItem::with_id(
+        app,
+        "menu-set-copy-format-rich",
+        "Rich text",
+        is_rich,
+        copy_as_rich,
+        Some("cmd+shift+m"),
+    )?;
+    let menu_copy_format_markdown_item = CheckMenuItem::with_id(
+        app,
+        "menu-set-copy-format-markdown",
+        "Markdown",
+        is_rich,
+        !copy_as_rich,
+        None::<&str>,
+    )?;
+    let menu_copy_format_submenu = Submenu::with_items(
+        app,
+        "Copy Format",
+        true,
+        &[&menu_copy_format_rich_item, &menu_copy_format_markdown_item],
     )?;
     let menu_clear_history_item = MenuItem::with_id(
         app,
@@ -285,6 +314,7 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                     &menu_show_history_folder_item,
                     &PredefinedMenuItem::separator(app)?,
                     &menu_send_to_clipboard_item,
+                    &menu_copy_format_submenu,
                 ],
             )?,
             &Submenu::with_items(
@@ -338,6 +368,8 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         menu_state.history_item = Some(menu_toggle_history_item);
         menu_state.editor_mode_rich = Some(menu_editor_mode_rich_item);
         menu_state.editor_mode_plain = Some(menu_editor_mode_plain_item);
+        menu_state.copy_format_rich = Some(menu_copy_format_rich_item);
+        menu_state.copy_format_markdown = Some(menu_copy_format_markdown_item);
     }
     app.on_menu_event(|app, event| match event.id().as_ref() {
         "menu-toggle-history" => {
@@ -404,6 +436,14 @@ fn setup_macos_menu(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             }
             emit_to_main_window(app, "menu-set-editor-mode", "plain");
         }
+        "menu-set-copy-format-rich" => {
+            set_copy_format_checks(app, true);
+            emit_to_main_window(app, "menu-set-copy-format", "rich");
+        }
+        "menu-set-copy-format-markdown" => {
+            set_copy_format_checks(app, false);
+            emit_to_main_window(app, "menu-set-copy-format", "markdown");
+        }
         "menu-clear-history" => {
             emit_to_main_window(app, "menu-clear-history", ());
         }
@@ -441,6 +481,31 @@ fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let settings_item =
         MenuItem::with_id(app, "open-settings", "Settings\u{2026}", true, None::<&str>)?;
     let quit_item = MenuItem::with_id(app, "quit-popmark", "Quit Popmark", true, None::<&str>)?;
+    let saved_settings = commands::get_settings(app.clone()).unwrap_or_default();
+    let is_rich = saved_settings.editor_mode != "plain";
+    let copy_as_rich = saved_settings.copy_as_rich_text && is_rich;
+    let tray_copy_format_rich_item = CheckMenuItem::with_id(
+        app,
+        "tray-set-copy-format-rich",
+        "Rich text",
+        is_rich,
+        copy_as_rich,
+        None::<&str>,
+    )?;
+    let tray_copy_format_markdown_item = CheckMenuItem::with_id(
+        app,
+        "tray-set-copy-format-markdown",
+        "Markdown",
+        is_rich,
+        !copy_as_rich,
+        None::<&str>,
+    )?;
+    let tray_copy_format_submenu = Submenu::with_items(
+        app,
+        "Copy Format",
+        true,
+        &[&tray_copy_format_rich_item, &tray_copy_format_markdown_item],
+    )?;
     let tray_menu = Menu::with_items(
         app,
         &[
@@ -448,9 +513,17 @@ fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
             &history_item,
             &settings_item,
             &PredefinedMenuItem::separator(app)?,
+            &tray_copy_format_submenu,
+            &PredefinedMenuItem::separator(app)?,
             &quit_item,
         ],
     )?;
+    {
+        let app_state = app.state::<AppState>();
+        let mut menu_state = app_state.menu.lock().expect("mutex poisoned: menu");
+        menu_state.tray_copy_format_rich = Some(tray_copy_format_rich_item);
+        menu_state.tray_copy_format_markdown = Some(tray_copy_format_markdown_item);
+    }
     let mut builder =
         TrayIconBuilder::new()
             .menu(&tray_menu)
@@ -464,6 +537,14 @@ fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 }
                 "open-settings" => {
                     let _ = commands::show_settings_window(app.clone());
+                }
+                "tray-set-copy-format-rich" => {
+                    set_copy_format_checks(app, true);
+                    emit_to_main_window(app, "menu-set-copy-format", "rich");
+                }
+                "tray-set-copy-format-markdown" => {
+                    set_copy_format_checks(app, false);
+                    emit_to_main_window(app, "menu-set-copy-format", "markdown");
                 }
                 "quit-popmark" => {
                     app.exit(0);
@@ -486,6 +567,24 @@ fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     }
     builder.build(app)?;
     Ok(())
+}
+
+// Immediately correct the Copy Format checkmarks (app menu + tray); macOS
+// auto-toggles on click. The frontend re-syncs via set_copy_format_menu.
+fn set_copy_format_checks(app: &AppHandle, rich: bool) {
+    let app_state = app.state::<AppState>();
+    let menu = app_state.menu.lock().expect("mutex poisoned: menu");
+    for (rich_item, md_item) in [
+        (&menu.copy_format_rich, &menu.copy_format_markdown),
+        (&menu.tray_copy_format_rich, &menu.tray_copy_format_markdown),
+    ] {
+        if let Some(item) = rich_item.as_ref() {
+            let _ = item.set_checked(rich);
+        }
+        if let Some(item) = md_item.as_ref() {
+            let _ = item.set_checked(!rich);
+        }
+    }
 }
 
 fn emit_to_main_window(app: &AppHandle, event: &str, payload: impl Serialize + Clone) {

--- a/src/components/SendToClipboardButton.tsx
+++ b/src/components/SendToClipboardButton.tsx
@@ -1,18 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+import type { EditorMode } from "../types/settings";
 import { formatHotkey } from "../utils/hotkey";
 
 export interface SendToClipboardButtonProps {
   onSend: () => void;
   sendShortcut: string;
+  copyAsRichText: boolean;
+  editorMode: EditorMode;
+  onSetCopyFormat: (rich: boolean) => void;
 }
 
-export function SendToClipboardButton({ onSend, sendShortcut }: SendToClipboardButtonProps) {
+export function SendToClipboardButton({
+  onSend,
+  sendShortcut,
+  copyAsRichText,
+  editorMode,
+  onSetCopyFormat,
+}: SendToClipboardButtonProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Plain mode forces Markdown; the rich preference only applies in rich mode.
+  const isRich = copyAsRichText && editorMode === "rich";
+  const dropdownDisabled = editorMode === "plain";
+  const label = isRich ? "Send Rich Text to Clipboard" : "Send Markdown to Clipboard";
+
+  // Close the dropdown when clicking outside of it.
+  useEffect(() => {
+    if (!open) return;
+    function handlePointerDown(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [open]);
+
+  function choose(rich: boolean) {
+    onSetCopyFormat(rich);
+    setOpen(false);
+  }
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      <button
+        type="button"
+        onClick={onSend}
+        className="bg-blue-500 text-white rounded-l hover:bg-blue-600 active:bg-blue-700 px-3 py-1.5 text-sm cursor-default"
+      >
+        {label} ({formatHotkey(sendShortcut)})
+      </button>
+      <button
+        type="button"
+        aria-label="Choose copy format"
+        disabled={dropdownDisabled}
+        onClick={() => setOpen((v) => !v)}
+        className="bg-blue-500 text-white rounded-r border-l border-blue-400 hover:bg-blue-600 active:bg-blue-700 px-2 py-1.5 text-sm cursor-default disabled:opacity-50"
+      >
+        <span aria-hidden="true">▾</span>
+      </button>
+      {open && !dropdownDisabled && (
+        <div className="absolute bottom-full right-0 mb-1 min-w-44 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg py-1 text-sm text-gray-900 dark:text-gray-100 z-10">
+          <CopyFormatItem label="Rich text" checked={isRich} onClick={() => choose(true)} />
+          <CopyFormatItem label="Markdown" checked={!isRich} onClick={() => choose(false)} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CopyFormatItemProps {
+  label: string;
+  checked: boolean;
+  onClick: () => void;
+}
+
+function CopyFormatItem({ label, checked, onClick }: CopyFormatItemProps) {
   return (
     <button
       type="button"
-      onClick={onSend}
-      className="bg-blue-500 text-white rounded hover:bg-blue-600 active:bg-blue-700 px-3 py-1.5 text-sm cursor-default"
+      onClick={onClick}
+      className="flex w-full items-center gap-2 px-3 py-1.5 text-left cursor-default hover:bg-gray-100 dark:hover:bg-gray-700"
     >
-      Send to clipboard ({formatHotkey(sendShortcut)})
+      <span className="w-4 shrink-0 text-blue-500">{checked ? "✓" : ""}</span>
+      {label}
     </button>
   );
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -64,7 +64,6 @@ export function SettingsPanel() {
   const [isCapturingSend, setIsCapturingSend] = useState(false);
   const [launchAtLogin, setLaunchAtLogin] = useState(false);
   const [showDockIcon, setShowDockIcon] = useState<boolean>(true);
-  const [copyAsRichText, setCopyAsRichText] = useState(false);
   const [notifyOnCopy, setNotifyOnCopy] = useState<boolean>(true);
   const [richShowSyntaxMarkers, setRichShowSyntaxMarkers] = useState<boolean>(true);
   const [maxHistoryEntries, setMaxHistoryEntries] = useState<string>("");
@@ -79,7 +78,6 @@ export function SettingsPanel() {
         setCapturedHotkey(s.hotkey);
         setLaunchAtLogin(s.launch_at_login);
         setShowDockIcon(s.show_dock_icon ?? true);
-        setCopyAsRichText(s.copy_as_rich_text);
         setNotifyOnCopy(s.notify_on_copy ?? true);
         setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
         const limit = s.max_history_entries;
@@ -140,7 +138,6 @@ export function SettingsPanel() {
         hotkey: capturedHotkey,
         launch_at_login: launchAtLogin,
         show_dock_icon: showDockIcon,
-        copy_as_rich_text: copyAsRichText,
         max_history_entries:
           maxHistoryEntries.trim() !== "" && parsedLimit > 0 ? parsedLimit : null,
         rich_font_family: fontState.richFontFamily.trim() || null,
@@ -216,19 +213,6 @@ export function SettingsPanel() {
           checked={showDockIcon}
           onChange={setShowDockIcon}
           label="Show Dock icon"
-          className="mb-3"
-        />
-
-        {/* Copy as Rich Text */}
-        <CheckboxSetting
-          checked={copyAsRichText}
-          onChange={setCopyAsRichText}
-          label={
-            <>
-              Copy as Rich Text{" "}
-              <span className="text-xs text-gray-400 dark:text-gray-500">(Rich mode only)</span>
-            </>
-          }
           className="mb-3"
         />
 

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -85,6 +85,12 @@ export function MarkdownEditor({
     onModeChange(editorMode === "rich" ? "plain" : "rich");
   }, [editorMode, onModeChange]);
 
+  // Persist the rich/markdown copy format and reflect it in local state.
+  const applyCopyFormat = useCallback((rich: boolean) => {
+    setCopyAsRichText(rich);
+    invoke("save_copy_as_rich_text", { value: rich });
+  }, []);
+
   const handleClearAll = useCallback(() => {
     if (editorMode === "plain") {
       const textarea = textareaRef.current;
@@ -166,6 +172,7 @@ export function MarkdownEditor({
     copyToClipboard,
     setCopyAsRichText,
     setSendShortcut,
+    applyCopyFormat,
     setIsHistoryOpen,
     onToggleHistory: () => setIsHistoryOpen((v) => !v),
     onClearHistory: handleClearHistory,
@@ -209,6 +216,12 @@ export function MarkdownEditor({
     invoke("set_editor_mode_menu", { mode: editorMode });
   }, [editorMode]);
 
+  // Sync copy format to the Copy Format submenu (app menu + tray). Plain mode
+  // forces Markdown, so the submenu is disabled there.
+  useEffect(() => {
+    invoke("set_copy_format_menu", { rich: copyAsRichText, enabled: editorMode === "rich" });
+  }, [copyAsRichText, editorMode]);
+
   // Load history entries when the panel opens
   useEffect(() => {
     if (isHistoryOpen) {
@@ -231,6 +244,13 @@ export function MarkdownEditor({
         handleClearAll();
         return;
       }
+      // ⌘⇧M toggles the copy format (rich ⇄ markdown); markdown is forced in
+      // plain mode, so the toggle only applies in rich mode.
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.key.toLowerCase() === "m") {
+        e.preventDefault();
+        if (editorMode === "rich") applyCopyFormat(!copyAsRichText);
+        return;
+      }
       if (e.key === "Escape") {
         e.preventDefault();
         getCurrentWindow().hide();
@@ -238,7 +258,7 @@ export function MarkdownEditor({
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [copyToClipboard, editorMode, sendShortcut, handleClearAll]);
+  }, [copyToClipboard, editorMode, sendShortcut, handleClearAll, applyCopyFormat, copyAsRichText]);
 
   // Load a pending history entry into the editor (with confirmation if there
   // is existing content). new_document archives the current draft to history.
@@ -342,7 +362,13 @@ export function MarkdownEditor({
           />
         </div>
         <div className="popmark-footer flex justify-end items-center px-3 py-2 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 select-none">
-          <SendToClipboardButton onSend={copyToClipboard} sendShortcut={sendShortcut} />
+          <SendToClipboardButton
+            onSend={copyToClipboard}
+            sendShortcut={sendShortcut}
+            copyAsRichText={copyAsRichText}
+            editorMode={editorMode}
+            onSetCopyFormat={applyCopyFormat}
+          />
         </div>
       </div>
     </>

--- a/src/hooks/useMenuEventListeners.ts
+++ b/src/hooks/useMenuEventListeners.ts
@@ -19,6 +19,7 @@ interface UseMenuEventListenersOptions {
   copyToClipboard: () => void;
   setCopyAsRichText: (v: boolean) => void;
   setSendShortcut: (v: string) => void;
+  applyCopyFormat: (rich: boolean) => void;
   setIsHistoryOpen: (open: boolean) => void;
   onToggleHistory: () => void;
   onClearHistory: () => void;
@@ -35,6 +36,7 @@ export function useMenuEventListeners({
   copyToClipboard,
   setCopyAsRichText,
   setSendShortcut,
+  applyCopyFormat,
   setIsHistoryOpen,
   onToggleHistory,
   onClearHistory,
@@ -106,6 +108,16 @@ export function useMenuEventListeners({
       handleModeToggle();
     },
     [handleModeToggle, editorMode],
+  );
+
+  useMenuEvent<string>(
+    "menu-set-copy-format",
+    (event) => {
+      // Plain mode forces Markdown; ignore format changes there.
+      if (editorMode === "plain") return;
+      applyCopyFormat(event.payload === "rich");
+    },
+    [applyCopyFormat, editorMode],
   );
 
   useMenuEvent("menu-clear-history", onClearHistory, [onClearHistory]);


### PR DESCRIPTION
## Summary

Moves the rich-text/markdown copy format choice out of Settings and onto the **Send to Clipboard** button itself, modeled after GitHub's PR merge button.

- The button is now a **split button**: a main action plus a ▾ dropdown to pick **Rich text** / **Markdown**. The main label reflects the current choice (`Send Rich Text to Clipboard` / `Send Markdown to Clipboard`).
- The same toggle is available from a **Copy Format** submenu in the app menu bar and the tray (status bar) icon menu, and via the **`⌘⇧M`** shortcut.
- The chosen format is persisted across launches (the existing `copy_as_rich_text` setting is reused; the "Copy as Rich Text" checkbox is removed from Settings).
- **Plain mode always copies Markdown**: the format is forced to Markdown and the toggle is disabled while in Plain mode; switching back to Rich mode restores the previously selected format.

## Implementation notes

- The effective copy logic (`copyAsRichText && editorMode === "rich"`) is unchanged, so "force markdown in Plain / restore on Rich" comes for free — `copy_as_rich_text` is never mutated while in Plain mode.
- New IPC commands `save_copy_as_rich_text` and `set_copy_format_menu` (mirroring `save_editor_mode` / `set_editor_mode_menu`). `save_settings` now preserves the on-disk `copy_as_rich_text` (like `editor_mode`) so saving the Settings panel never clobbers the chosen format.
- All four surfaces (split button, app menu, tray menu, `⌘⇧M`) stay in sync via `set_copy_format_menu`.
- `docs/REQUIREMENTS.md` and `docs/SPEC.md` updated.

## Verification

- `npm run build`, `npm run check` (Biome + cargo fmt + clippy), and `cargo check` all pass.
- Manual checks recommended via `npm run tauri dev`: split-button dropdown, `⌘⇧M`, app menu / tray Copy Format, Plain-mode forcing/restoring, persistence across restart, and that saving other settings no longer resets the format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)