### PR TITLE
ci: auto-tag and release on version bump merge to main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,45 @@
+name: Check
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run check:ci:js
+
+      - name: Build
+        run: npm run build
+
+  rust:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          components: rustfmt, clippy
+
+      - name: Check
+        run: npm run check:rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -10,39 +8,5 @@ permissions:
   contents: read
 
 jobs:
-  frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: lts/*
-          cache: npm
-
-      - run: npm ci
-
-      - name: Lint
-        run: npm run check:ci:js
-
-      - name: Build
-        run: npm run build
-
-  rust:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: lts/*
-          cache: npm
-
-      - run: npm ci
-
-      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
-        with:
-          components: rustfmt, clippy
-
-      - name: Check
-        run: npm run check:rust
+  check:
+    uses: ./.github/workflows/check.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,58 @@
+name: Main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    uses: ./.github/workflows/check.yml
+
+  tag:
+    name: Tag on version bump
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Checkout with a PAT so that the tag pushed below triggers the Release
+      # workflow. Pushes made with the default GITHUB_TOKEN do not trigger
+      # subsequent workflow runs by design.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+
+      - name: Resolve and verify version
+        id: version
+        run: |
+          PKG_VER=$(jq -r .version package.json)
+          CARGO_VER=$(grep '^version' src-tauri/Cargo.toml | head -1 | cut -d'"' -f2)
+          TAURI_VER=$(jq -r .version src-tauri/tauri.conf.json)
+
+          if [ "$PKG_VER" != "$CARGO_VER" ] || [ "$PKG_VER" != "$TAURI_VER" ]; then
+            echo "::error::version mismatch: package.json=$PKG_VER Cargo.toml=$CARGO_VER tauri.conf.json=$TAURI_VER"
+            exit 1
+          fi
+
+          echo "version=$PKG_VER" >> "$GITHUB_OUTPUT"
+
+      - name: Check tag existence
+        id: tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -21,11 +21,16 @@ npm run tauri dev
 
 | Trigger | Workflow | What it does |
 |---------|----------|--------------|
-| push / PR to `main` | CI | Lint, type-check, build (frontend + Rust) |
+| PR to `main` | CI | Lint, type-check, build (frontend + Rust) |
+| push to `main` | Main | Run the same checks, then auto-create and push the `vX.Y.Z` tag when `package.json` introduces a new version |
 | push of `vX.Y.Z` tag | Release | Build macOS app, publish GitHub Release with `.zip` and `.dmg` |
 | GitHub Release published | Update Homebrew tap | Opens a PR against [dayflower/homebrew-tap](https://github.com/dayflower/homebrew-tap) |
 
-The release workflow verifies that all three version files (`package.json`, `Cargo.toml`, `tauri.conf.json`) match the tag before building. If any mismatch is detected, the build fails.
+The shared checks live in a reusable workflow (`check.yml`) called by both CI and Main.
+
+The Main workflow tags only when no tag for the current version exists yet, and it verifies that all three version files (`package.json`, `Cargo.toml`, `tauri.conf.json`) agree before tagging. It pushes the tag using a PAT (`RELEASE_GITHUB_TOKEN`) so that the tag push triggers the Release workflow — pushes made with the default `GITHUB_TOKEN` do not trigger subsequent workflow runs.
+
+The Release workflow independently re-verifies that all three version files match the tag before building. If any mismatch is detected, the build fails.
 
 ## Release Procedure
 
@@ -46,24 +51,15 @@ This script:
 
 ### 2. Wait for the version bump PR to merge
 
-CI must pass for auto-merge to proceed. Once merged, sync `main`:
-
-```sh
-git checkout main && git pull
-```
-
-### 3. Push the release tag
-
-```sh
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
+CI must pass for auto-merge to proceed. Once the PR merges to `main`, the Main
+workflow runs the checks and then automatically creates and pushes the `vX.Y.Z`
+tag for the new version. No manual tagging is required.
 
 Pushing the tag triggers the Release workflow. The resulting GitHub Release includes:
 - `popmark-X.Y.Z-macos.zip` — `.app` bundle (for Homebrew)
 - `popmark-X.Y.Z-macos.dmg` — disk image (for direct download)
 
-### 4. Verify release artifacts
+### 3. Verify release artifacts
 
 - Confirm the GitHub Release is created with both assets attached.
 - The Homebrew tap workflow opens a PR against `dayflower/homebrew-tap` automatically — review and merge it.


### PR DESCRIPTION
## Summary

Automates the release flow so that merging a version-bump PR into `main` triggers tagging and the full release chain — eliminating the manual `git tag` / `git push` step.

Previously, after merging a version-bump PR you had to manually create and push a `vX.Y.Z` tag to start the Release workflow. Now the push to `main` does this automatically.

## New flow

```
version bump PR merge → main push
  → main.yml: check (CI) → tag (verify version + push tag via PAT)
    → release.yml (tag-triggered): build + publish GitHub Release
      → homebrew-tap.yml (release published): update Homebrew tap
```

## Changes

- **`.github/workflows/check.yml`** (new) — extracts the CI checks (frontend lint/build + Rust check) into a reusable workflow (`workflow_call`).
- **`.github/workflows/ci.yml`** (modified) — now PR-only; just calls `check.yml`.
- **`.github/workflows/main.yml`** (new) — runs on push to `main`. After `check` passes, the `tag` job verifies all three version files agree (`package.json` / `Cargo.toml` / `tauri.conf.json`) and, if no tag for that version exists yet, creates and pushes `vX.Y.Z`.
- **`docs/DEVELOPMENT.md`** — updated CI/CD table and release procedure to reflect the automated tagging.

## Notes

- The tag is pushed using the existing PAT (`RELEASE_GITHUB_TOKEN`) so that the tag push triggers the Release workflow — pushes made with the default `GITHUB_TOKEN` do not trigger subsequent workflow runs by design.
- Tagging is idempotent: on a regular push where the version is unchanged, the existing-tag check skips creation.
- `release.yml` is unchanged and still re-verifies version consistency before building.

## Verification

- YAML syntax validated for all three workflows.
- CI on this PR exercises the refactored `ci.yml` → `check.yml` path.
- End-to-end tag automation will be confirmed on the next version bump via the Actions UI.