### PR TITLE
fix: clear editor when controlled value is reset after programmatic load

### DIFF
--- a/src/lexical-markdown/plugins/ControlledValuePlugin.tsx
+++ b/src/lexical-markdown/plugins/ControlledValuePlugin.tsx
@@ -1,5 +1,6 @@
 import {
   $convertFromMarkdownString,
+  $convertToMarkdownString,
   type Transformer,
 } from "@lexical/markdown";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -30,6 +31,12 @@ export default function ControlledValuePlugin({
     editor.update(
       () => {
         $convertFromMarkdownString(value, transformers);
+        // Advance the shared guard to the editor's actual serialized content so
+        // a later programmatic `value` (e.g. New Document setting "") is
+        // detected as a real change, and so a genuine edit afterwards doesn't
+        // echo-reimport. OnChangePlugin only updates this ref for user-driven
+        // (non-CONTROLLED) updates, leaving it stale after a controlled import.
+        lastEmittedRef.current = $convertToMarkdownString(transformers);
       },
       { tag: UPDATE_TAGS.CONTROLLED },
     );


### PR DESCRIPTION
## Summary

Fixes a bug where **New Document (and Clear All / history recall) did not clear the rich editor** after content had been set programmatically.

## Root cause

In the vendored `ControlledValuePlugin`, the guard `if (lastEmittedRef.current === value) return;` decides whether to import an incoming `value`. That shared `lastEmittedRef` is only advanced by `OnChangePlugin`, which skips `CONTROLLED`-tagged updates — i.e. the controlled imports this plugin itself performs.

As a result, after a programmatic `setContent(...)` flows into the editor, `lastEmittedRef` stays stale (typically the initial `""`). A subsequent `setContent("")` (New Document / Clear All) then matches the stale `lastEmittedRef.current === ""` and the clearing import is skipped, so the editor keeps its old content.

Repro:
- Recall a history entry into an empty editor, then New Document → **editor not cleared** (deterministic).
- Launch with a saved draft auto-loaded, then New Document → intermittently not cleared (races the 100ms OnChange debounce vs the `get_draft` IPC).

## Fix

Advance `lastEmittedRef` to the editor's **actual serialized content** right after each controlled import, so the guard always tracks the last markdown pushed into / emitted from the editor. Using the serialized content (rather than the raw `value`) avoids an extra re-import / selection reset when `$convertFromMarkdownString` normalizes the input.

The typing echo-loop guard (selection preservation) is unaffected: on user input the guard matches and returns before reaching the new line, which only runs on programmatic value changes.

Single file changed: `src/lexical-markdown/plugins/ControlledValuePlugin.tsx`.

## Verification

`npm run tauri dev`, rich mode:
- Recall a history entry → New Document → editor clears.
- Write → hide (Escape) → reopen (draft restored) → New Document → editor clears.
- Clear All (⌘⇧Backspace) clears the editor.
- Typing mid-document does not jump the caret to the start (no echo re-import).
- Plain mode unaffected (textarea is outside the Lexical composer).

`npm run check` (Biome + cargo fmt/clippy) passes.