### PR TITLE
ci: build on macos-26 SDK so traffic lights render correctly on Tahoe

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,9 @@ jobs:
         run: npm run build
 
   rust:
-    runs-on: macos-latest
+    # Match the release build's macOS SDK (see release.yml) so CI checks the
+    # same toolchain that ships.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
 
   build-and-release:
     name: Build and release
-    runs-on: macos-latest
+    # Build against the latest macOS SDK so window chrome (traffic-light
+    # positions) renders natively on each OS. Building with an older SDK than
+    # the running OS (e.g. SDK 15 on macOS 26 Tahoe) shifts the buttons down.
+    runs-on: macos-26
     needs: check-version
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The traffic-light buttons sit noticeably too low in the **CI-built** app, while a local build looks correct.

Root cause: the buttons' position is interpreted against the title-bar metrics of the macOS SDK the binary is *linked* against. The release runner (`macos-latest` → resolves to `macos-15`) builds with the macOS 15 SDK, but the app runs on macOS 26 (Tahoe), whose window chrome was redesigned. An app linked with an older SDK than the running OS gets compatibility-mode metrics, shifting the buttons down. Local builds use the SDK 26 toolchain (Command Line Tools 26.x), so they look correct.

`trafficLightPosition` in `tauri.conf.json` is a single static value and cannot be correct across the Sequoia↔Tahoe title-bar redesign. Tauri 2.11 does not expose a runtime traffic-light inset setter, so adjusting it in code would require fragile native frame manipulation.

## Change

Build CI against the latest macOS SDK by pinning the runners to `macos-26`:

- `release.yml`: `macos-latest` → `macos-26`
- `check.yml`: `macos-latest` → `macos-26` (match the shipping toolchain)

Building with the latest SDK is Apple's recommended approach and lets AppKit render window chrome natively on each OS. The deployment target is unchanged, so this does **not** raise the minimum supported macOS version.

## Notes

- No application code changes; this is CI-only.
- Verify on the first release run that the runner actually reports macOS 26 / SDK 26.
- Sequoia behavior is assumed correct under the "latest SDK = native per-OS behavior" model; not verified on a Sequoia device.