### PR TITLE
chore: bump version to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tauri-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tauri-app",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@lexical/code": "^0.45.0",
         "@lexical/code-core": "^0.45.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tauri-app",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist dist-ssr src-tauri/target src-tauri/gen/schemas",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "popmark"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "font-enumeration",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "popmark"
-version = "1.0.0"
+version = "1.0.1"
 description = "A popup Markdown editor triggered by a global shortcut"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Popmark",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.eula.dayflower.popmark",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Version bump: v1.0.1

Automated version bump via `scripts/bump-version.sh patch`.

### Changed files
- `package.json`
- `package-lock.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock`
- `src-tauri/tauri.conf.json`

### Next step

After this PR is merged, create and push the release tag:

```sh
git checkout main && git pull
git tag v1.0.1
git push origin v1.0.1
```