### PR TITLE
fix: pin Xcode to 26.4.1 for macOS bundle to avoid actool crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Xcode 26.5 (the macos-26 runner default) ships an actool that crashes
+      # while compiling Liquid Glass `.icon` bundles into Assets.car (Apple bug
+      # FB20183399), breaking the macOS bundle step. Pin to 26.4.1, which is
+      # also preinstalled on the runner and compiles `.icon` correctly.
+      - name: Select Xcode 26.4.1 (actool .icon workaround)
+        run: sudo xcode-select -s /Applications/Xcode_26.4.1.app
+
       - name: Build Tauri app (ad-hoc signing)
         env:
           APPLE_SIGNING_IDENTITY: "-"


### PR DESCRIPTION
## Problem

The v1.3.0 release build failed at the macOS bundle step:

```
Failed to create app Assets.car: `failed to run actool`
```

The `macos-26` runner's default Xcode **26.5** ships an `actool` that crashes while compiling Liquid Glass `.icon` bundles (added in c145516) into `Assets.car` — Apple bug FB20183399. v1.3.0 was the first release to bundle a `.icon`, so this only surfaced now. Tauri's bundler swallows actool's stderr, so the log only showed the generic `failed to run actool`.

- Xcode **26.5** → fails
- Xcode **26.4.1** → works (and is preinstalled on the `macos-26` runner)

## Fix

Select the preinstalled Xcode 26.4.1 before the bundle step in `release.yml`. Only `release.yml` bundles the macOS app (the `check.yml` macOS job runs `check:rust` and does not invoke actool), so no other workflow needs changing.

Once Apple fixes the regression in a later Xcode, this step can be removed to fall back to the runner default.

## Notes

- YAML validated.
- Not build-verified locally (no full Xcode available); the fix targets the runner toolchain.

Refs: https://github.com/expo/expo/issues/46121