### PR TITLE
feat: colorize code block syntax and add highlight toggle

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -322,6 +322,7 @@ After the user saves, the backend emits a `settings-changed` event to the main w
 | Max history entries  | 0 (unlimited)      | Maximum number of history entries to retain; oldest are auto-deleted when a new entry exceeds the limit |
 | Notify on copy       | On                 | When enabled, an OS notification is sent after "Send to Clipboard". Stored as `notify_on_copy` in `settings.json`. |
 | Show syntax markers  | On                 | When enabled (Rich mode only), displays Markdown syntax markers as CSS pseudo-elements. Applies the `.show-syntax-markers` class to the `ContentEditable`. Stored as `rich_show_syntax_markers` in `settings.json`. Defaults to `true` when absent. |
+| Syntax highlight     | On                 | When enabled (Rich mode only), Prism tokenizes fenced code blocks and the `.token.*` color rules in `src/index.css` colorize them (light/dark variants via `prefers-color-scheme`). When disabled, the `prismLanguages` prop is withheld so code blocks render as plain monospace text with no token spans. Stored as `rich_syntax_highlight` in `settings.json`. Defaults to `true` when absent. |
 | Show Dock icon       | On                 | When enabled, sets macOS activation policy to `Regular` (Dock + Cmd+Tab + menu bar). When disabled, sets policy to `Accessory` (hidden from Dock, Cmd+Tab, and menu bar; tray and global hotkey remain). Stored as `show_dock_icon` in `settings.json`. Defaults to `true` when absent. Applied at startup and immediately on save. |
 | Rich mode font family | null (browser default) | Custom `font-family` applied to the Rich mode `ContentEditable` via inline style |
 | Rich mode font size  | null (default)     | Custom `font-size` (px) applied to the Rich mode `ContentEditable` via inline style |
@@ -346,11 +347,12 @@ The copy format preference (`copy_as_rich_text`) is **not** part of the Settings
   "send_shortcut": "super+enter",
   "notify_on_copy": true,
   "rich_show_syntax_markers": true,
+  "rich_syntax_highlight": true,
   "show_dock_icon": true
 }
 ```
 
-All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`). `rich_show_syntax_markers` defaults to `true` when absent (`#[serde(default = "default_rich_show_syntax_markers")]`). `show_dock_icon` defaults to `true` when absent (`#[serde(default = "default_show_dock_icon")]`).
+All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`). `rich_show_syntax_markers` defaults to `true` when absent (`#[serde(default = "default_rich_show_syntax_markers")]`). `rich_syntax_highlight` defaults to `true` when absent (`#[serde(default = "default_rich_syntax_highlight")]`). `show_dock_icon` defaults to `true` when absent (`#[serde(default = "default_show_dock_icon")]`).
 
 ---
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -67,6 +67,8 @@ pub struct Settings {
     pub notify_on_copy: bool,
     #[serde(default = "default_rich_show_syntax_markers")]
     pub rich_show_syntax_markers: bool,
+    #[serde(default = "default_rich_syntax_highlight")]
+    pub rich_syntax_highlight: bool,
     #[serde(default = "default_show_dock_icon")]
     pub show_dock_icon: bool,
 }
@@ -76,6 +78,7 @@ const DEFAULT_SEND_SHORTCUT: &str = "super+enter";
 const DEFAULT_FONT_FALLBACK: bool = true;
 const DEFAULT_NOTIFY_ON_COPY: bool = true;
 const DEFAULT_RICH_SHOW_SYNTAX_MARKERS: bool = true;
+const DEFAULT_RICH_SYNTAX_HIGHLIGHT: bool = true;
 const DEFAULT_SHOW_DOCK_ICON: bool = true;
 
 fn default_editor_mode() -> String {
@@ -96,6 +99,10 @@ fn default_notify_on_copy() -> bool {
 
 fn default_rich_show_syntax_markers() -> bool {
     DEFAULT_RICH_SHOW_SYNTAX_MARKERS
+}
+
+fn default_rich_syntax_highlight() -> bool {
+    DEFAULT_RICH_SYNTAX_HIGHLIGHT
 }
 
 fn default_show_dock_icon() -> bool {
@@ -119,6 +126,7 @@ impl Default for Settings {
             send_shortcut: DEFAULT_SEND_SHORTCUT.to_string(),
             notify_on_copy: DEFAULT_NOTIFY_ON_COPY,
             rich_show_syntax_markers: DEFAULT_RICH_SHOW_SYNTAX_MARKERS,
+            rich_syntax_highlight: DEFAULT_RICH_SYNTAX_HIGHLIGHT,
             show_dock_icon: DEFAULT_SHOW_DOCK_ICON,
         }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
   const [plainFontFamily, setPlainFontFamily] = useState<string | null>(null);
   const [plainFontSize, setPlainFontSize] = useState<number | null>(null);
   const [richShowSyntaxMarkers, setRichShowSyntaxMarkers] = useState<boolean>(true);
+  const [richSyntaxHighlight, setRichSyntaxHighlight] = useState<boolean>(true);
 
   useEffect(() => {
     invoke<Settings>("get_settings").then((s) => {
@@ -26,6 +27,7 @@ function App() {
       );
       setPlainFontSize(s.plain_font_size ?? null);
       setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
+      setRichSyntaxHighlight(s.rich_syntax_highlight ?? true);
       setSettingsLoaded(true);
     });
   }, []);
@@ -42,6 +44,7 @@ function App() {
       );
       setPlainFontSize(s.plain_font_size ?? null);
       setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
+      setRichSyntaxHighlight(s.rich_syntax_highlight ?? true);
     });
     return () => {
       unlisten.then((fn) => fn());
@@ -76,6 +79,7 @@ function App() {
         plainFontFamily={plainFontFamily}
         plainFontSize={plainFontSize}
         richShowSyntaxMarkers={richShowSyntaxMarkers}
+        richSyntaxHighlight={richSyntaxHighlight}
       />
     </div>
   );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -66,6 +66,7 @@ export function SettingsPanel() {
   const [showDockIcon, setShowDockIcon] = useState<boolean>(true);
   const [notifyOnCopy, setNotifyOnCopy] = useState<boolean>(true);
   const [richShowSyntaxMarkers, setRichShowSyntaxMarkers] = useState<boolean>(true);
+  const [richSyntaxHighlight, setRichSyntaxHighlight] = useState<boolean>(true);
   const [maxHistoryEntries, setMaxHistoryEntries] = useState<string>("");
   const [fontState, dispatchFont] = useReducer(fontReducer, initialFontState);
   const [fontList, setFontList] = useState<string[]>([]);
@@ -80,6 +81,7 @@ export function SettingsPanel() {
         setShowDockIcon(s.show_dock_icon ?? true);
         setNotifyOnCopy(s.notify_on_copy ?? true);
         setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
+        setRichSyntaxHighlight(s.rich_syntax_highlight ?? true);
         const limit = s.max_history_entries;
         setMaxHistoryEntries(limit != null && limit > 0 ? String(limit) : "");
         const sendShortcut = s.send_shortcut ?? "super+enter";
@@ -151,6 +153,7 @@ export function SettingsPanel() {
         send_shortcut: capturedSendShortcut,
         notify_on_copy: notifyOnCopy,
         rich_show_syntax_markers: richShowSyntaxMarkers,
+        rich_syntax_highlight: richSyntaxHighlight,
       },
     });
     setSavedHotkey(capturedHotkey);
@@ -250,6 +253,21 @@ export function SettingsPanel() {
             <>
               Show syntax markers{" "}
               <span className="text-xs text-gray-400 dark:text-gray-500">(Rich mode only)</span>
+            </>
+          }
+          className="mb-3"
+        />
+
+        {/* Syntax highlight in Rich Editor */}
+        <CheckboxSetting
+          checked={richSyntaxHighlight}
+          onChange={setRichSyntaxHighlight}
+          label={
+            <>
+              Syntax highlight{" "}
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                (Rich mode, code blocks)
+              </span>
             </>
           }
           className="mb-4"

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -31,6 +31,7 @@ interface MarkdownEditorProps {
   plainFontFamily?: string | null;
   plainFontSize?: number | null;
   richShowSyntaxMarkers?: boolean;
+  richSyntaxHighlight?: boolean;
 }
 
 export function MarkdownEditor({
@@ -41,6 +42,7 @@ export function MarkdownEditor({
   plainFontFamily,
   plainFontSize,
   richShowSyntaxMarkers = true,
+  richSyntaxHighlight = true,
 }: MarkdownEditorProps) {
   // Single source of truth: the markdown string shared by both editor modes.
   const [content, setContent] = useState("");
@@ -333,7 +335,7 @@ export function MarkdownEditor({
                 editorRef={editorRef}
                 features={POPMARK_FEATURES}
                 classNames={POPMARK_CLASS_NAMES}
-                prismLanguages={PRISM_LANGUAGES}
+                prismLanguages={richSyntaxHighlight ? PRISM_LANGUAGES : undefined}
                 rootClassName="h-full"
                 className="lexical-md__content w-full h-full overflow-y-auto p-4 outline-none text-sm text-gray-900 dark:text-gray-100"
                 contentEditableProps={{

--- a/src/index.css
+++ b/src/index.css
@@ -200,6 +200,97 @@ body {
   border-radius: 0;
 }
 
+/* ---------- Prism syntax-highlight token colors (GitHub-ish palette) ---------- */
+.lexical-md__content .md-code-block .token.comment,
+.lexical-md__content .md-code-block .token.prolog,
+.lexical-md__content .md-code-block .token.doctype,
+.lexical-md__content .md-code-block .token.cdata {
+  color: #6a737d;
+  font-style: italic;
+}
+.lexical-md__content .md-code-block .token.punctuation {
+  color: #24292e;
+}
+.lexical-md__content .md-code-block .token.property,
+.lexical-md__content .md-code-block .token.tag,
+.lexical-md__content .md-code-block .token.boolean,
+.lexical-md__content .md-code-block .token.number,
+.lexical-md__content .md-code-block .token.constant,
+.lexical-md__content .md-code-block .token.symbol,
+.lexical-md__content .md-code-block .token.deleted {
+  color: #005cc5;
+}
+.lexical-md__content .md-code-block .token.selector,
+.lexical-md__content .md-code-block .token.attr-name,
+.lexical-md__content .md-code-block .token.string,
+.lexical-md__content .md-code-block .token.char,
+.lexical-md__content .md-code-block .token.builtin,
+.lexical-md__content .md-code-block .token.inserted {
+  color: #22863a;
+}
+.lexical-md__content .md-code-block .token.operator,
+.lexical-md__content .md-code-block .token.entity,
+.lexical-md__content .md-code-block .token.url,
+.lexical-md__content .md-code-block .token.atrule,
+.lexical-md__content .md-code-block .token.attr-value,
+.lexical-md__content .md-code-block .token.keyword {
+  color: #d73a49;
+}
+.lexical-md__content .md-code-block .token.function,
+.lexical-md__content .md-code-block .token.class-name {
+  color: #6f42c1;
+}
+.lexical-md__content .md-code-block .token.regex,
+.lexical-md__content .md-code-block .token.important,
+.lexical-md__content .md-code-block .token.variable {
+  color: #e36209;
+}
+@media (prefers-color-scheme: dark) {
+  .lexical-md__content .md-code-block .token.comment,
+  .lexical-md__content .md-code-block .token.prolog,
+  .lexical-md__content .md-code-block .token.doctype,
+  .lexical-md__content .md-code-block .token.cdata {
+    color: #8b949e;
+  }
+  .lexical-md__content .md-code-block .token.punctuation {
+    color: #c9d1d9;
+  }
+  .lexical-md__content .md-code-block .token.property,
+  .lexical-md__content .md-code-block .token.tag,
+  .lexical-md__content .md-code-block .token.boolean,
+  .lexical-md__content .md-code-block .token.number,
+  .lexical-md__content .md-code-block .token.constant,
+  .lexical-md__content .md-code-block .token.symbol,
+  .lexical-md__content .md-code-block .token.deleted {
+    color: #79c0ff;
+  }
+  .lexical-md__content .md-code-block .token.selector,
+  .lexical-md__content .md-code-block .token.attr-name,
+  .lexical-md__content .md-code-block .token.string,
+  .lexical-md__content .md-code-block .token.char,
+  .lexical-md__content .md-code-block .token.builtin,
+  .lexical-md__content .md-code-block .token.inserted {
+    color: #7ee787;
+  }
+  .lexical-md__content .md-code-block .token.operator,
+  .lexical-md__content .md-code-block .token.entity,
+  .lexical-md__content .md-code-block .token.url,
+  .lexical-md__content .md-code-block .token.atrule,
+  .lexical-md__content .md-code-block .token.attr-value,
+  .lexical-md__content .md-code-block .token.keyword {
+    color: #ff7b72;
+  }
+  .lexical-md__content .md-code-block .token.function,
+  .lexical-md__content .md-code-block .token.class-name {
+    color: #d2a8ff;
+  }
+  .lexical-md__content .md-code-block .token.regex,
+  .lexical-md__content .md-code-block .token.important,
+  .lexical-md__content .md-code-block .token.variable {
+    color: #ffa657;
+  }
+}
+
 /* ---------- horizontal rule ---------- */
 .lexical-md__content hr {
   border: 0;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -15,5 +15,6 @@ export interface Settings {
   send_shortcut?: string;
   notify_on_copy?: boolean;
   rich_show_syntax_markers?: boolean;
+  rich_syntax_highlight?: boolean;
   show_dock_icon?: boolean;
 }


### PR DESCRIPTION
## Summary

Code blocks in the rich editor already had Prism token classes (`token comment`, `token keyword`, …) applied, but no CSS ever colorized them, so highlighting appeared inert. This PR adds the missing token colors and a setting to turn syntax highlighting on/off.

## Changes

- **Token colors** (`src/index.css`): GitHub-ish `.token.*` color rules scoped to `.md-code-block`, with light/dark variants via `@media (prefers-color-scheme: dark)` to match the app's existing OS-driven dark mode.
- **On/off setting** `rich_syntax_highlight` (default on), wired through the existing `rich_show_syntax_markers` pattern:
  - Rust `Settings` field + `#[serde(default)]` + `Default` impl (`src-tauri/src/commands.rs`)
  - TS type (`src/types/settings.ts`)
  - Settings panel checkbox + load/save (`src/components/SettingsPanel.tsx`)
  - App state / `settings-changed` listener / prop passing (`src/App.tsx`)
  - When off, `prismLanguages` is withheld so code blocks render as plain monospace text with no token spans (no tokenization cost, no stray classes) — see `CodeHighlightingPlugin`.
- **Docs**: `docs/SPEC.md` settings table, schema, and defaults updated.

## Verification

- `npx tsc --noEmit`, `npm run check` (Biome + clippy + fmt), and `cargo check` all pass.