### PR TITLE
Add color theme support (Auto/Light/Dark/Color)

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -129,6 +129,7 @@ The copy format is chosen directly at the point of copying rather than buried in
 | Plain mode font size | Custom font size (in px) for the Plain mode textarea. When empty, the default size is used. |
 | Show syntax markers | When enabled (Rich mode only), displays Markdown syntax markers (`**`, `*`, `~~`, `` ` ``, `#`–`######`) as CSS decorations alongside the formatted text (default: on). |
 | Show Dock icon | When enabled (default), the app appears in the macOS Dock, Cmd+Tab, and menu bar. When disabled, the app is accessible only via the system tray icon and global hotkey (macOS Accessory activation policy). |
+| Appearance (theme) | **Auto** (follow OS light/dark, default), **Light**, **Dark**, or **Color**. Color is an independent theme: pick one of a curated set of preset colors (Red, Orange, Yellow, Green, Blue, Purple, Slate), and a scope of either **Title bar** (soft-tints just the toolbar / Settings header) or **Whole window** (also washes the editing area and footer with a light tint). Applies to both the main editor window and the Settings window. Buttons and checkboxes throughout the app (e.g. "Save", "Send to Clipboard", the task-list checkbox) also adopt the selected preset as their primary accent color. |
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -123,7 +123,7 @@ A prominent primary-action **split button** sits in the **footer bar at the bott
 
 - **Layout:** a main button plus a ▾ dropdown (GitHub merge-button style). The dropdown lists **Rich text** / **Markdown** as a radio-style choice with a check on the current format; selecting one calls `onSetCopyFormat(rich)`.
 - **Label:** reflects the current format — `Send Rich Text to Clipboard (⌘↵)` or `Send Markdown to Clipboard (⌘↵)`. The shortcut hint is rendered dynamically via `formatHotkey(sendShortcut)`.
-- **Style:** `bg-blue-500 text-white` split into `rounded-l` (main) and `rounded-r` (dropdown) segments.
+- **Style:** `bg-(--popmark-primary) text-white` (the theme's primary accent — see §12.2) split into `rounded-l` (main) and `rounded-r` (dropdown) segments.
 - **Behavior:** the main button performs the copy in the current format (copy Markdown, and HTML too when Rich Text) — save to history, clear draft, hide window.
 - **Plain mode:** the format is forced to Markdown; the ▾ dropdown is disabled. Switching back to Rich mode restores the previously selected format (the saved `copy_as_rich_text` preference is preserved untouched while in Plain mode).
 - The format can also be changed from the **Copy Format** submenu (app menu + tray) and the `⌘⇧M` shortcut; all surfaces stay in sync via `set_copy_format_menu`.
@@ -322,12 +322,15 @@ After the user saves, the backend emits a `settings-changed` event to the main w
 | Max history entries  | 0 (unlimited)      | Maximum number of history entries to retain; oldest are auto-deleted when a new entry exceeds the limit |
 | Notify on copy       | On                 | When enabled, an OS notification is sent after "Send to Clipboard". Stored as `notify_on_copy` in `settings.json`. |
 | Show syntax markers  | On                 | When enabled (Rich mode only), displays Markdown syntax markers as CSS pseudo-elements. Applies the `.show-syntax-markers` class to the `ContentEditable`. Stored as `rich_show_syntax_markers` in `settings.json`. Defaults to `true` when absent. |
-| Syntax highlight     | On                 | When enabled (Rich mode only), Prism tokenizes fenced code blocks and the `.token.*` color rules in `src/index.css` colorize them (light/dark variants via `prefers-color-scheme`). When disabled, the `prismLanguages` prop is withheld so code blocks render as plain monospace text with no token spans. Stored as `rich_syntax_highlight` in `settings.json`. Defaults to `true` when absent. |
+| Syntax highlight     | On                 | When enabled (Rich mode only), Prism tokenizes fenced code blocks and the `.token.*` color rules in `src/index.css` colorize them (light/dark variants via the `.dark` class — see §12.2). When disabled, the `prismLanguages` prop is withheld so code blocks render as plain monospace text with no token spans. Stored as `rich_syntax_highlight` in `settings.json`. Defaults to `true` when absent. |
 | Show Dock icon       | On                 | When enabled, sets macOS activation policy to `Regular` (Dock + Cmd+Tab + menu bar). When disabled, sets policy to `Accessory` (hidden from Dock, Cmd+Tab, and menu bar; tray and global hotkey remain). Stored as `show_dock_icon` in `settings.json`. Defaults to `true` when absent. Applied at startup and immediately on save. |
 | Rich mode font family | null (browser default) | Custom `font-family` applied to the Rich mode `ContentEditable` via inline style |
 | Rich mode font size  | null (default)     | Custom `font-size` (px) applied to the Rich mode `ContentEditable` via inline style |
 | Plain mode font family | null (browser default) | Custom `font-family` applied to the Plain mode `<textarea>` via inline style |
 | Plain mode font size | null (default)     | Custom `font-size` (px) applied to the Plain mode `<textarea>` via inline style |
+| Theme                | `auto`             | `auto` (follow OS `prefers-color-scheme`), `light`, `dark`, or `color`. Stored as `theme` in `settings.json`. See §12.2 for the rendering architecture. |
+| Color preset          | null (falls back to `red`) | Preset id for Color theme (`red`/`orange`/`yellow`/`green`/`blue`/`purple`/`slate`, in that display order). Stored as `color_preset` in `settings.json`. Ignored unless `theme` is `color`. |
+| Color scope           | `chrome`            | `chrome` (tint the toolbar / Settings header — the true "title bar" — only) or `window` (also wash the editing area, footer, and Settings body with a light tint of the preset). Stored as `color_scope` in `settings.json`. Ignored unless `theme` is `color`. |
 
 The copy format preference (`copy_as_rich_text`) is **not** part of the Settings UI. It is still persisted in `settings.json` but is managed from the "Send to Clipboard" split button, the Copy Format menus, and `⌘⇧M` (via `save_copy_as_rich_text`). Like `editor_mode`, `save_settings` preserves the on-disk value so saving the Settings panel never clobbers the chosen format.
 
@@ -348,11 +351,24 @@ The copy format preference (`copy_as_rich_text`) is **not** part of the Settings
   "notify_on_copy": true,
   "rich_show_syntax_markers": true,
   "rich_syntax_highlight": true,
-  "show_dock_icon": true
+  "show_dock_icon": true,
+  "theme": "auto",
+  "color_preset": null,
+  "color_scope": "chrome"
 }
 ```
 
-All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`). `rich_show_syntax_markers` defaults to `true` when absent (`#[serde(default = "default_rich_show_syntax_markers")]`). `rich_syntax_highlight` defaults to `true` when absent (`#[serde(default = "default_rich_syntax_highlight")]`). `show_dock_icon` defaults to `true` when absent (`#[serde(default = "default_show_dock_icon")]`).
+All font fields are optional (`#[serde(default)]`) and absent keys deserialize as `None` for backwards compatibility. `send_shortcut` defaults to `"super+enter"` when absent (`#[serde(default = "default_send_shortcut")]`). `notify_on_copy` defaults to `true` when absent (`#[serde(default = "default_notify_on_copy")]`). `rich_show_syntax_markers` defaults to `true` when absent (`#[serde(default = "default_rich_show_syntax_markers")]`). `rich_syntax_highlight` defaults to `true` when absent (`#[serde(default = "default_rich_syntax_highlight")]`). `show_dock_icon` defaults to `true` when absent (`#[serde(default = "default_show_dock_icon")]`). `theme` defaults to `"auto"` when absent (`#[serde(default = "default_theme")]`). `color_preset` defaults to `None` when absent (`#[serde(default)]`) and is resolved to the first entry of `THEME_PRESETS` (`red`) by the frontend when unset or unrecognized. `color_scope` defaults to `"chrome"` when absent (`#[serde(default = "default_color_scope")]`).
+
+### 12.2 Theming Architecture
+
+Tailwind's `dark:` variant is switched from its default OS-media-query resolution to a class-based one via `@custom-variant dark (&:where(.dark, .dark *));` in `src/index.css`. All `dark:` utilities across the app, and the hand-written dark-mode rules for Markdown rendering (link/code/code-block/Prism tokens/hr/task-checkbox, also in `src/index.css`), now activate off an ancestor `.dark` class rather than `prefers-color-scheme` directly. This axis (Light/Dark/Auto) is entirely separate from the Color theme below — Color mode never touches the `dark` class.
+
+- `src/utils/theme.ts` — `THEME_PRESETS` (curated preset list; each entry has a vivid `swatchColor` plus soft `accent`/`accentBorder`/`surfaceTint` shades) and the pure `applyTheme(theme, colorPreset, colorScope, osDark)` function. It sets `document.documentElement`'s `dark` class (Light/Dark/Auto axis only), `data-theme-mode`, `data-color-scope`, and four CSS custom properties: `--popmark-accent` / `--popmark-accent-border` (toolbar/header tint), `--popmark-surface-tint` (editing-area/footer wash in `window` scope), and `--popmark-primary` (buttons/checkboxes accent, see below). No IPC, no React — safe to call both from settings load and from live UI previews.
+- `src/hooks/useTheme.ts` — loads `theme`/`color_preset`/`color_scope` via `get_settings`, tracks `matchMedia("(prefers-color-scheme: dark)")` for `auto`, re-syncs on the `settings-changed` and `settings-window-shown` events, and calls `applyTheme` on change. A pure side-effect hook (returns `void`) — call once per window root (`App.tsx`, `SettingsApp.tsx`).
+- Color theme styling is driven entirely by CSS attribute selectors reacting to `data-theme-mode`/`data-color-scope` on `<html>` — no React props or inline styles are threaded through components for it. `.popmark-toolbar` / `.popmark-settings-header` (the true "title bar", independent of scope) get `var(--popmark-accent)`; `.popmark-surface` / `.popmark-settings-root` (the editing area, the footer, and the Settings body — i.e. everything *except* the title bar) get `var(--popmark-surface-tint)` only in `window` scope. Because these surfaces are intentionally soft/light, they need no text-color changes — normal light-mode text/link/code colors stay legible.
+- **Primary UI accent** (`--popmark-primary`, defined in `src/index.css`): defaults to the app's original blue; when Color theme is active, `applyTheme` overrides it to the active preset's `swatchColor`. Buttons (Settings "Save", the "Send to Clipboard" split button) and checkboxes (`CheckboxSetting`, `FontSettings`' fallback checkbox, the Markdown task-checkbox) reference it via Tailwind's `bg-(--popmark-primary)` / `accent-(--popmark-primary)` arbitrary-property syntax instead of hardcoded `blue-*` classes. Hover/active/divider shades (`--popmark-primary-hover`, `--popmark-primary-active`, `--popmark-primary-divider`) are derived from it live via `color-mix()`, so no per-preset hover values are needed. Markdown link colors and the hotkey-capture highlight intentionally stay the fixed blue — only interactive "primary action" controls follow the theme.
+- `src/components/ThemeSettings.tsx` calls `applyTheme` directly on every draft-state change for instant live preview in the Settings window, independent of the persisted-value round trip; Cancel/Esc reverts by re-calling `applyTheme` with the last-saved values.
 
 ---
 

--- a/src-tauri/capabilities/settings.json
+++ b/src-tauri/capabilities/settings.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "settings",
+  "description": "Capability for the settings window",
+  "windows": ["settings"],
+  "permissions": ["core:default", "core:window:allow-start-dragging"]
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -71,6 +71,12 @@ pub struct Settings {
     pub rich_syntax_highlight: bool,
     #[serde(default = "default_show_dock_icon")]
     pub show_dock_icon: bool,
+    #[serde(default = "default_theme")]
+    pub theme: String,
+    #[serde(default)]
+    pub color_preset: Option<String>,
+    #[serde(default = "default_color_scope")]
+    pub color_scope: String,
 }
 
 const DEFAULT_EDITOR_MODE: &str = "rich";
@@ -80,6 +86,8 @@ const DEFAULT_NOTIFY_ON_COPY: bool = true;
 const DEFAULT_RICH_SHOW_SYNTAX_MARKERS: bool = true;
 const DEFAULT_RICH_SYNTAX_HIGHLIGHT: bool = true;
 const DEFAULT_SHOW_DOCK_ICON: bool = true;
+const DEFAULT_THEME: &str = "auto";
+const DEFAULT_COLOR_SCOPE: &str = "chrome";
 
 fn default_editor_mode() -> String {
     DEFAULT_EDITOR_MODE.to_string()
@@ -109,6 +117,14 @@ fn default_show_dock_icon() -> bool {
     DEFAULT_SHOW_DOCK_ICON
 }
 
+fn default_theme() -> String {
+    DEFAULT_THEME.to_string()
+}
+
+fn default_color_scope() -> String {
+    DEFAULT_COLOR_SCOPE.to_string()
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Settings {
@@ -128,6 +144,9 @@ impl Default for Settings {
             rich_show_syntax_markers: DEFAULT_RICH_SHOW_SYNTAX_MARKERS,
             rich_syntax_highlight: DEFAULT_RICH_SYNTAX_HIGHLIGHT,
             show_dock_icon: DEFAULT_SHOW_DOCK_ICON,
+            theme: DEFAULT_THEME.to_string(),
+            color_preset: None,
+            color_scope: DEFAULT_COLOR_SCOPE.to_string(),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,14 +52,16 @@ pub fn run() {
                 use window_vibrancy::{
                     apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,
                 };
-                if let Some(window) = handle.get_webview_window("main") {
-                    apply_vibrancy(
-                        &window,
-                        NSVisualEffectMaterial::HeaderView,
-                        Some(NSVisualEffectState::Active),
-                        None,
-                    )
-                    .expect("apply_vibrancy failed for main window");
+                for label in ["main", "settings"] {
+                    if let Some(window) = handle.get_webview_window(label) {
+                        apply_vibrancy(
+                            &window,
+                            NSVisualEffectMaterial::HeaderView,
+                            Some(NSVisualEffectState::Active),
+                            None,
+                        )
+                        .unwrap_or_else(|_| panic!("apply_vibrancy failed for {label} window"));
+                    }
                 }
             }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,14 @@
         "resizable": false,
         "visible": false,
         "decorations": true,
-        "alwaysOnTop": true
+        "alwaysOnTop": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "transparent": true,
+        "trafficLightPosition": {
+          "x": 20,
+          "y": 28
+        }
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,12 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import { MarkdownEditor } from "./editor/MarkdownEditor";
+import { useTheme } from "./hooks/useTheme";
 import type { EditorMode, Settings } from "./types/settings";
 import { composeFontFamily, PLAIN_FALLBACK_STACK, RICH_FALLBACK_STACK } from "./utils/font";
 
 function App() {
+  useTheme();
   const [editorMode, setEditorMode] = useState<EditorMode>("rich");
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [richFontFamily, setRichFontFamily] = useState<string | null>(null);

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -1,8 +1,10 @@
 import { SettingsPanel } from "./components/SettingsPanel";
+import { useTheme } from "./hooks/useTheme";
 
 export default function SettingsApp() {
+  useTheme();
   return (
-    <div className="h-screen bg-white dark:bg-gray-800 flex flex-col">
+    <div className="popmark-settings-root h-screen bg-white dark:bg-gray-800 flex flex-col">
       <SettingsPanel />
     </div>
   );

--- a/src/components/CheckboxSetting.tsx
+++ b/src/components/CheckboxSetting.tsx
@@ -13,7 +13,7 @@ export function CheckboxSetting({ checked, onChange, label, className }: Checkbo
           type="checkbox"
           checked={checked}
           onChange={(e) => onChange(e.target.checked)}
-          className="w-4 h-4 accent-blue-500"
+          className="w-4 h-4 accent-(--popmark-primary)"
         />
         <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
       </label>

--- a/src/components/FontSettings.tsx
+++ b/src/components/FontSettings.tsx
@@ -37,7 +37,7 @@ export function FontSettings({
           value={fontFamily}
           onChange={(e) => onFontFamilyChange(e.target.value)}
           placeholder="Family…"
-          className="flex-1 min-w-0 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
+          className="flex-1 min-w-0 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-(--popmark-primary)"
         />
         <input
           type="number"
@@ -45,7 +45,7 @@ export function FontSettings({
           value={fontSize}
           onChange={(e) => onFontSizeChange(e.target.value)}
           placeholder="px"
-          className="w-14 px-2 py-1 text-sm text-right border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
+          className="w-14 px-2 py-1 text-sm text-right border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-(--popmark-primary)"
         />
       </div>
       <label className="flex items-center gap-2 cursor-pointer select-none">
@@ -53,7 +53,7 @@ export function FontSettings({
           type="checkbox"
           checked={fontFallback}
           onChange={(e) => onFontFallbackChange(e.target.checked)}
-          className="w-4 h-4 accent-blue-500"
+          className="w-4 h-4 accent-(--popmark-primary)"
         />
         <span className="text-xs text-gray-600 dark:text-gray-400">Append fallback fonts</span>
       </label>

--- a/src/components/SendToClipboardButton.tsx
+++ b/src/components/SendToClipboardButton.tsx
@@ -47,7 +47,7 @@ export function SendToClipboardButton({
       <button
         type="button"
         onClick={onSend}
-        className="bg-blue-500 text-white rounded-l hover:bg-blue-600 active:bg-blue-700 px-3 py-1.5 text-sm cursor-default"
+        className="bg-(--popmark-primary) text-white rounded-l hover:bg-(--popmark-primary-hover) active:bg-(--popmark-primary-active) px-3 py-1.5 text-sm cursor-default"
       >
         {label} ({formatHotkey(sendShortcut)})
       </button>
@@ -56,7 +56,7 @@ export function SendToClipboardButton({
         aria-label="Choose copy format"
         disabled={dropdownDisabled}
         onClick={() => setOpen((v) => !v)}
-        className="bg-blue-500 text-white rounded-r border-l border-blue-400 hover:bg-blue-600 active:bg-blue-700 px-2 py-1.5 text-sm cursor-default disabled:opacity-50"
+        className="bg-(--popmark-primary) text-white rounded-r border-l border-(--popmark-primary-divider) hover:bg-(--popmark-primary-hover) active:bg-(--popmark-primary-active) px-2 py-1.5 text-sm cursor-default disabled:opacity-50"
       >
         <span aria-hidden="true">▾</span>
       </button>
@@ -83,7 +83,7 @@ function CopyFormatItem({ label, checked, onClick }: CopyFormatItemProps) {
       onClick={onClick}
       className="flex w-full items-center gap-2 px-3 py-1.5 text-left cursor-default hover:bg-gray-100 dark:hover:bg-gray-700"
     >
-      <span className="w-4 shrink-0 text-blue-500">{checked ? "✓" : ""}</span>
+      <span className="w-4 shrink-0 text-(--popmark-primary)">{checked ? "✓" : ""}</span>
       {label}
     </button>
   );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,10 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useReducer, useState } from "react";
-import type { Settings } from "../types/settings";
+import type { ColorScope, Settings, ThemeMode } from "../types/settings";
+import { applyTheme } from "../utils/theme";
 import { CheckboxSetting } from "./CheckboxSetting";
 import { FontSettings } from "./FontSettings";
 import { HotkeyCapture } from "./HotkeyCapture";
+import { ThemeSettings } from "./ThemeSettings";
 
 // --- Font state ---
 
@@ -70,6 +72,14 @@ export function SettingsPanel() {
   const [maxHistoryEntries, setMaxHistoryEntries] = useState<string>("");
   const [fontState, dispatchFont] = useReducer(fontReducer, initialFontState);
   const [fontList, setFontList] = useState<string[]>([]);
+  const [theme, setTheme] = useState<ThemeMode>("auto");
+  const [savedTheme, setSavedTheme] = useState<ThemeMode>("auto");
+  const [colorPreset, setColorPreset] = useState<string | null>(null);
+  const [savedColorPreset, setSavedColorPreset] = useState<string | null>(null);
+  const [colorScope, setColorScope] = useState<ColorScope>("chrome");
+  const [savedColorScope, setSavedColorScope] = useState<ColorScope>("chrome");
+
+  const osDark = useCallback(() => window.matchMedia("(prefers-color-scheme: dark)").matches, []);
 
   // Load settings on mount and whenever the settings window is shown
   useEffect(() => {
@@ -82,6 +92,15 @@ export function SettingsPanel() {
         setNotifyOnCopy(s.notify_on_copy ?? true);
         setRichShowSyntaxMarkers(s.rich_show_syntax_markers ?? true);
         setRichSyntaxHighlight(s.rich_syntax_highlight ?? true);
+        const loadedTheme = (s.theme as ThemeMode) ?? "auto";
+        const loadedColorPreset = s.color_preset ?? null;
+        const loadedColorScope = (s.color_scope as ColorScope) ?? "chrome";
+        setTheme(loadedTheme);
+        setSavedTheme(loadedTheme);
+        setColorPreset(loadedColorPreset);
+        setSavedColorPreset(loadedColorPreset);
+        setColorScope(loadedColorScope);
+        setSavedColorScope(loadedColorScope);
         const limit = s.max_history_entries;
         setMaxHistoryEntries(limit != null && limit > 0 ? String(limit) : "");
         const sendShortcut = s.send_shortcut ?? "super+enter";
@@ -117,8 +136,12 @@ export function SettingsPanel() {
     setCapturedHotkey(savedHotkey);
     setIsCapturingSend(false);
     setCapturedSendShortcut(savedSendShortcut);
+    setTheme(savedTheme);
+    setColorPreset(savedColorPreset);
+    setColorScope(savedColorScope);
+    applyTheme(savedTheme, savedColorPreset, savedColorScope, osDark());
     invoke("hide_settings_window");
-  }, [savedHotkey, savedSendShortcut]);
+  }, [savedHotkey, savedSendShortcut, savedTheme, savedColorPreset, savedColorScope, osDark]);
 
   // ESC to cancel (when not capturing)
   useEffect(() => {
@@ -154,17 +177,46 @@ export function SettingsPanel() {
         notify_on_copy: notifyOnCopy,
         rich_show_syntax_markers: richShowSyntaxMarkers,
         rich_syntax_highlight: richSyntaxHighlight,
+        theme,
+        color_preset: colorPreset,
+        color_scope: colorScope,
       },
     });
     setSavedHotkey(capturedHotkey);
     setSavedSendShortcut(capturedSendShortcut);
+    setSavedTheme(theme);
+    setSavedColorPreset(colorPreset);
+    setSavedColorScope(colorScope);
     invoke("hide_settings_window");
   }
 
   return (
     <div className="flex flex-col h-full">
+      <div
+        data-tauri-drag-region
+        className="popmark-settings-header flex items-center px-6 py-4 border-b border-gray-200 dark:border-gray-700"
+      >
+        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Settings</h2>
+      </div>
       <div className="flex-1 min-h-0 overflow-y-auto px-6 pt-6">
-        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-4">Settings</h2>
+        {/* Appearance / theme */}
+        <ThemeSettings
+          theme={theme}
+          colorPreset={colorPreset}
+          colorScope={colorScope}
+          onThemeChange={(t) => {
+            setTheme(t);
+            applyTheme(t, colorPreset, colorScope, osDark());
+          }}
+          onPresetChange={(presetId) => {
+            setColorPreset(presetId);
+            applyTheme(theme, presetId, colorScope, osDark());
+          }}
+          onScopeChange={(scope) => {
+            setColorScope(scope);
+            applyTheme(theme, colorPreset, scope, osDark());
+          }}
+        />
 
         {/* Global shortcut */}
         <div className="mb-3">
@@ -240,7 +292,7 @@ export function SettingsPanel() {
               value={maxHistoryEntries}
               onChange={(e) => setMaxHistoryEntries(e.target.value)}
               placeholder="∞"
-              className="w-20 px-2 py-1 text-sm text-right border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-blue-500"
+              className="w-20 px-2 py-1 text-sm text-right border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded outline-none focus:border-(--popmark-primary)"
             />
           </label>
         </div>
@@ -314,7 +366,7 @@ export function SettingsPanel() {
         <button
           type="button"
           onClick={handleSave}
-          className="px-4 py-1.5 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 active:bg-blue-700 cursor-default"
+          className="px-4 py-1.5 text-sm bg-(--popmark-primary) text-white rounded hover:bg-(--popmark-primary-hover) active:bg-(--popmark-primary-active) cursor-default"
         >
           Save
         </button>

--- a/src/components/ThemeSettings.tsx
+++ b/src/components/ThemeSettings.tsx
@@ -1,0 +1,96 @@
+import { Check } from "lucide-react";
+import type { ColorScope, ThemeMode } from "../types/settings";
+import { THEME_PRESETS } from "../utils/theme";
+
+interface ThemeSettingsProps {
+  theme: ThemeMode;
+  colorPreset: string | null;
+  colorScope: ColorScope;
+  onThemeChange: (theme: ThemeMode) => void;
+  onPresetChange: (presetId: string) => void;
+  onScopeChange: (scope: ColorScope) => void;
+}
+
+const THEME_MODES: { mode: ThemeMode; label: string }[] = [
+  { mode: "auto", label: "Auto" },
+  { mode: "light", label: "Light" },
+  { mode: "dark", label: "Dark" },
+  { mode: "color", label: "Color" },
+];
+
+const COLOR_SCOPES: { scope: ColorScope; label: string }[] = [
+  { scope: "chrome", label: "Title bar" },
+  { scope: "window", label: "Whole window" },
+];
+
+export function ThemeSettings({
+  theme,
+  colorPreset,
+  colorScope,
+  onThemeChange,
+  onPresetChange,
+  onScopeChange,
+}: ThemeSettingsProps) {
+  return (
+    <div className="mb-4">
+      <span className="block text-sm text-gray-700 dark:text-gray-300 mb-2">Appearance</span>
+      <div className="flex rounded overflow-hidden border border-gray-300 dark:border-gray-600 w-fit">
+        {THEME_MODES.map(({ mode, label }) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onThemeChange(mode)}
+            className={[
+              "px-3 py-1.5 text-sm cursor-default",
+              theme === mode
+                ? "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+                : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700",
+            ].join(" ")}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {theme === "color" && (
+        <div className="mt-3 flex flex-col gap-3">
+          <div className="flex gap-2">
+            {THEME_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => onPresetChange(preset.id)}
+                title={preset.label}
+                aria-label={preset.label}
+                style={{ backgroundColor: preset.swatchColor }}
+                className={[
+                  "w-6 h-6 rounded-full flex items-center justify-center cursor-default ring-offset-2 ring-offset-white dark:ring-offset-gray-800",
+                  colorPreset === preset.id ? "ring-2 ring-gray-500 dark:ring-gray-300" : "",
+                ].join(" ")}
+              >
+                {colorPreset === preset.id && <Check size={14} className="text-white" />}
+              </button>
+            ))}
+          </div>
+          <div className="flex rounded overflow-hidden border border-gray-300 dark:border-gray-600 w-fit">
+            {COLOR_SCOPES.map(({ scope, label }) => (
+              <button
+                key={scope}
+                type="button"
+                onClick={() => onScopeChange(scope)}
+                className={[
+                  "px-3 py-1.5 text-sm cursor-default",
+                  colorScope === scope
+                    ? "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+                    : "text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700",
+                ].join(" ")}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/editor/MarkdownEditor.tsx
+++ b/src/editor/MarkdownEditor.tsx
@@ -309,7 +309,7 @@ export function MarkdownEditor({
         editorMode={editorMode}
         onModeToggle={handleModeToggle}
       />
-      <div className="relative flex-1 flex flex-col overflow-hidden bg-white dark:bg-gray-900">
+      <div className="relative flex-1 flex flex-col overflow-hidden popmark-surface bg-white dark:bg-gray-900">
         <div className="flex-1 overflow-hidden relative">
           {editorMode === "plain" ? (
             <textarea
@@ -317,7 +317,7 @@ export function MarkdownEditor({
               value={content}
               onChange={(e) => setContent(e.target.value)}
               onKeyDown={handlePlainKeyDown}
-              className="w-full h-full p-4 outline-none resize-none font-mono text-sm text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900"
+              className="w-full h-full p-4 outline-none resize-none font-mono text-sm text-gray-900 dark:text-gray-100 popmark-surface bg-white dark:bg-gray-900"
               style={{
                 fontFamily: plainFontFamily ?? undefined,
                 fontSize: plainFontSize ? `${plainFontSize}px` : undefined,
@@ -363,7 +363,7 @@ export function MarkdownEditor({
             onClearAll={clearHistory}
           />
         </div>
-        <div className="popmark-footer flex justify-end items-center px-3 py-2 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 select-none">
+        <div className="popmark-footer popmark-surface flex justify-end items-center px-3 py-2 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 select-none">
           <SendToClipboardButton
             onSend={copyToClipboard}
             sendShortcut={sendShortcut}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,50 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+import type { ColorScope, Settings, ThemeMode } from "../types/settings";
+import { applyTheme } from "../utils/theme";
+import { useMenuEvent } from "./useMenuEvent";
+
+/**
+ * Loads the persisted theme, keeps it in sync with settings changes and OS
+ * appearance changes, and applies it to the document root. Call once per
+ * window root (App.tsx, SettingsApp.tsx) — calling it again elsewhere would
+ * duplicate the matchMedia/event subscriptions. Pure side effect; the actual
+ * styling is driven by CSS reacting to the `data-theme-mode`/`data-color-scope`
+ * attributes and `--popmark-*` custom properties this hook writes to
+ * `document.documentElement` (see index.css and utils/theme.ts).
+ */
+export function useTheme(): void {
+  const [theme, setTheme] = useState<ThemeMode>("auto");
+  const [colorPreset, setColorPreset] = useState<string | null>(null);
+  const [colorScope, setColorScope] = useState<ColorScope>("chrome");
+  const [osDark, setOsDark] = useState(
+    () => window.matchMedia("(prefers-color-scheme: dark)").matches,
+  );
+
+  const applyFromSettings = (s: Settings) => {
+    setTheme((s.theme as ThemeMode) ?? "auto");
+    setColorPreset(s.color_preset ?? null);
+    setColorScope((s.color_scope as ColorScope) ?? "chrome");
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: applyFromSettings is intentionally omitted — only run on mount
+  useEffect(() => {
+    invoke<Settings>("get_settings").then(applyFromSettings);
+  }, []);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent) => setOsDark(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  useMenuEvent<Settings>("settings-changed", (event) => applyFromSettings(event.payload));
+  useMenuEvent("settings-window-shown", () => {
+    invoke<Settings>("get_settings").then(applyFromSettings);
+  });
+
+  useEffect(() => {
+    applyTheme(theme, colorPreset, colorScope, osDark);
+  }, [theme, colorPreset, colorScope, osDark]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,36 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* Primary UI accent (buttons, checkboxes). Defaults to the app's original
+   blue in Light/Dark/Auto; overridden to the selected preset's swatchColor
+   when Color theme is active (see applyTheme in src/utils/theme.ts). The
+   hover/active shades derive from it via color-mix() so buttons don't need
+   per-preset hover/active hex values. */
+:root {
+  --popmark-primary: #3b82f6;
+  --popmark-primary-hover: color-mix(in srgb, var(--popmark-primary) 85%, black);
+  --popmark-primary-active: color-mix(in srgb, var(--popmark-primary) 70%, black);
+  --popmark-primary-divider: color-mix(in srgb, var(--popmark-primary) 70%, white);
+}
+
+/* Color theme: accent tint applied via CSS vars + data attributes set by
+   useTheme/applyTheme (src/utils/theme.ts). `.popmark-toolbar` / `.popmark-settings-header`
+   are the true "title bar" — always tinted with the soft accent whenever Color
+   theme is active, independent of scope. `.popmark-surface` / `.popmark-settings-root`
+   (which also marks the footer, so it follows the main area, not the title bar)
+   are the "window" scope surfaces — tinted with an even lighter wash so
+   content stays legible with plain light-mode text/link/code colors. */
+html[data-theme-mode="color"] .popmark-toolbar,
+html[data-theme-mode="color"] .popmark-settings-header {
+  background-color: var(--popmark-accent);
+  border-color: var(--popmark-accent-border);
+}
+html[data-theme-mode="color"][data-color-scope="window"] .popmark-surface,
+html[data-theme-mode="color"][data-color-scope="window"] .popmark-settings-root {
+  background-color: var(--popmark-surface-tint);
+}
+
 /* Disable rubber-band overscroll on both main and settings windows */
 html,
 body {
@@ -18,6 +49,13 @@ body {
 [data-platform="macos"] .popmark-footer {
   height: 52px;
   padding: 0 16px;
+}
+
+/* The settings window uses the same Overlay title bar treatment as the main
+   window — reserve space for the traffic-light cluster in its header band. */
+[data-platform="macos"] .popmark-settings-header {
+  height: 52px;
+  padding: 0 16px 0 96px;
 }
 
 /* ===========================================================================
@@ -39,10 +77,8 @@ body {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.92em;
 }
-@media (prefers-color-scheme: dark) {
-  .md-code {
-    background: #374151;
-  }
+.dark .md-code {
+  background: #374151;
 }
 
 /* ---------- markdown link ---------- */
@@ -50,10 +86,8 @@ body {
   color: #2563eb;
   cursor: text;
 }
-@media (prefers-color-scheme: dark) {
-  .md-link {
-    color: #60a5fa;
-  }
+.dark .md-link {
+  color: #60a5fa;
 }
 
 .md-link[data-focused] .md-link-url {
@@ -88,10 +122,8 @@ body {
   line-height: 1.5;
   text-decoration: underline;
 }
-@media (prefers-color-scheme: dark) {
-  .md-link:not([data-focused]) .md-link-label::before {
-    color: #60a5fa;
-  }
+.dark .md-link:not([data-focused]) .md-link-label::before {
+  color: #60a5fa;
 }
 
 /* External-link icon (focused: dimmed, unfocused: full) */
@@ -132,10 +164,8 @@ body {
 [data-mod-pressed] .md-auto-link:hover {
   cursor: pointer;
 }
-@media (prefers-color-scheme: dark) {
-  .md-auto-link {
-    color: #60a5fa;
-  }
+.dark .md-auto-link {
+  color: #60a5fa;
 }
 .md-auto-link::after {
   content: "";
@@ -176,10 +206,8 @@ body {
   border-radius: inherit;
   background: #f1f5f9;
 }
-@media (prefers-color-scheme: dark) {
-  .md-code-block::before {
-    background: #1f2937;
-  }
+.dark .md-code-block::before {
+  background: #1f2937;
 }
 /* Unfocused: shrink the backdrop past the (hidden) fence lines. */
 .md-code-block:not([data-focused])::before {
@@ -245,50 +273,48 @@ body {
 .lexical-md__content .md-code-block .token.variable {
   color: #e36209;
 }
-@media (prefers-color-scheme: dark) {
-  .lexical-md__content .md-code-block .token.comment,
-  .lexical-md__content .md-code-block .token.prolog,
-  .lexical-md__content .md-code-block .token.doctype,
-  .lexical-md__content .md-code-block .token.cdata {
-    color: #8b949e;
-  }
-  .lexical-md__content .md-code-block .token.punctuation {
-    color: #c9d1d9;
-  }
-  .lexical-md__content .md-code-block .token.property,
-  .lexical-md__content .md-code-block .token.tag,
-  .lexical-md__content .md-code-block .token.boolean,
-  .lexical-md__content .md-code-block .token.number,
-  .lexical-md__content .md-code-block .token.constant,
-  .lexical-md__content .md-code-block .token.symbol,
-  .lexical-md__content .md-code-block .token.deleted {
-    color: #79c0ff;
-  }
-  .lexical-md__content .md-code-block .token.selector,
-  .lexical-md__content .md-code-block .token.attr-name,
-  .lexical-md__content .md-code-block .token.string,
-  .lexical-md__content .md-code-block .token.char,
-  .lexical-md__content .md-code-block .token.builtin,
-  .lexical-md__content .md-code-block .token.inserted {
-    color: #7ee787;
-  }
-  .lexical-md__content .md-code-block .token.operator,
-  .lexical-md__content .md-code-block .token.entity,
-  .lexical-md__content .md-code-block .token.url,
-  .lexical-md__content .md-code-block .token.atrule,
-  .lexical-md__content .md-code-block .token.attr-value,
-  .lexical-md__content .md-code-block .token.keyword {
-    color: #ff7b72;
-  }
-  .lexical-md__content .md-code-block .token.function,
-  .lexical-md__content .md-code-block .token.class-name {
-    color: #d2a8ff;
-  }
-  .lexical-md__content .md-code-block .token.regex,
-  .lexical-md__content .md-code-block .token.important,
-  .lexical-md__content .md-code-block .token.variable {
-    color: #ffa657;
-  }
+.dark .lexical-md__content .md-code-block .token.comment,
+.dark .lexical-md__content .md-code-block .token.prolog,
+.dark .lexical-md__content .md-code-block .token.doctype,
+.dark .lexical-md__content .md-code-block .token.cdata {
+  color: #8b949e;
+}
+.dark .lexical-md__content .md-code-block .token.punctuation {
+  color: #c9d1d9;
+}
+.dark .lexical-md__content .md-code-block .token.property,
+.dark .lexical-md__content .md-code-block .token.tag,
+.dark .lexical-md__content .md-code-block .token.boolean,
+.dark .lexical-md__content .md-code-block .token.number,
+.dark .lexical-md__content .md-code-block .token.constant,
+.dark .lexical-md__content .md-code-block .token.symbol,
+.dark .lexical-md__content .md-code-block .token.deleted {
+  color: #79c0ff;
+}
+.dark .lexical-md__content .md-code-block .token.selector,
+.dark .lexical-md__content .md-code-block .token.attr-name,
+.dark .lexical-md__content .md-code-block .token.string,
+.dark .lexical-md__content .md-code-block .token.char,
+.dark .lexical-md__content .md-code-block .token.builtin,
+.dark .lexical-md__content .md-code-block .token.inserted {
+  color: #7ee787;
+}
+.dark .lexical-md__content .md-code-block .token.operator,
+.dark .lexical-md__content .md-code-block .token.entity,
+.dark .lexical-md__content .md-code-block .token.url,
+.dark .lexical-md__content .md-code-block .token.atrule,
+.dark .lexical-md__content .md-code-block .token.attr-value,
+.dark .lexical-md__content .md-code-block .token.keyword {
+  color: #ff7b72;
+}
+.dark .lexical-md__content .md-code-block .token.function,
+.dark .lexical-md__content .md-code-block .token.class-name {
+  color: #d2a8ff;
+}
+.dark .lexical-md__content .md-code-block .token.regex,
+.dark .lexical-md__content .md-code-block .token.important,
+.dark .lexical-md__content .md-code-block .token.variable {
+  color: #ffa657;
 }
 
 /* ---------- horizontal rule ---------- */
@@ -297,10 +323,8 @@ body {
   border-top: 1px solid #d1d5db;
   margin: 1em 0;
 }
-@media (prefers-color-scheme: dark) {
-  .lexical-md__content hr {
-    border-top-color: #4b5563;
-  }
+.dark .lexical-md__content hr {
+  border-top-color: #4b5563;
 }
 
 /* ---------- task list ---------- */
@@ -326,8 +350,8 @@ body {
   vertical-align: middle;
 }
 .md-task-checked::before {
-  background: #3b82f6;
-  border-color: #3b82f6;
+  background: var(--popmark-primary);
+  border-color: var(--popmark-primary);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath fill='none' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M2 6l3 3 5-5'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: center;
@@ -347,18 +371,16 @@ body {
 .md-task.md-nested::before {
   content: none;
 }
-@media (prefers-color-scheme: dark) {
-  .md-task::before {
-    border-color: #6b7280;
-    background: #1f2937;
-  }
-  .md-task-checked::before {
-    background: #3b82f6;
-    border-color: #3b82f6;
-  }
-  .md-task-checked {
-    color: #6b7280;
-  }
+.dark .md-task::before {
+  border-color: #6b7280;
+  background: #1f2937;
+}
+.dark .md-task-checked::before {
+  background: var(--popmark-primary);
+  border-color: var(--popmark-primary);
+}
+.dark .md-task-checked {
+  color: #6b7280;
 }
 
 /* ===========================================================================
@@ -417,6 +439,9 @@ body {
   left: -0.4em;
   color: #64748b;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.dark [data-markdown-markup-mode] blockquote::before {
+  color: #94a3b8;
 }
 
 /* Link (focused): reveal the literal [label](url) source. While unfocused,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,5 +1,8 @@
 export type EditorMode = "rich" | "plain";
 
+export type ThemeMode = "auto" | "light" | "dark" | "color";
+export type ColorScope = "chrome" | "window";
+
 export interface Settings {
   hotkey: string;
   launch_at_login: boolean;
@@ -17,4 +20,7 @@ export interface Settings {
   rich_show_syntax_markers?: boolean;
   rich_syntax_highlight?: boolean;
   show_dock_icon?: boolean;
+  theme?: string;
+  color_preset?: string | null;
+  color_scope?: string;
 }

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,113 @@
+import type { ColorScope, ThemeMode } from "../types/settings";
+
+export interface ColorPreset {
+  id: string;
+  label: string;
+  /** Vivid color for the preset swatch picker, and the app's primary UI
+   * accent (buttons, checkboxes) when this preset is active. */
+  swatchColor: string;
+  /** Toolbar / settings-header background — a soft, low-saturation tint. */
+  accent: string;
+  /** Toolbar / settings-header border — one step deeper than accent. */
+  accentBorder: string;
+  /** Very light wash used for the editing surface (and footer) in "window"
+   * scope, so the main area reads as a soft tint rather than a solid block. */
+  surfaceTint: string;
+}
+
+export const THEME_PRESETS: ColorPreset[] = [
+  {
+    id: "red",
+    label: "Red",
+    swatchColor: "#ef4444",
+    accent: "#fecaca",
+    accentBorder: "#fca5a5",
+    surfaceTint: "#fef2f2",
+  },
+  {
+    id: "orange",
+    label: "Orange",
+    swatchColor: "#f97316",
+    accent: "#fed7aa",
+    accentBorder: "#fdba74",
+    surfaceTint: "#fff7ed",
+  },
+  {
+    id: "yellow",
+    label: "Yellow",
+    swatchColor: "#eab308",
+    accent: "#fef08a",
+    accentBorder: "#fde047",
+    surfaceTint: "#fefce8",
+  },
+  {
+    id: "green",
+    label: "Green",
+    swatchColor: "#22c55e",
+    accent: "#bbf7d0",
+    accentBorder: "#86efac",
+    surfaceTint: "#f0fdf4",
+  },
+  {
+    id: "blue",
+    label: "Blue",
+    swatchColor: "#3b82f6",
+    accent: "#bfdbfe",
+    accentBorder: "#93c5fd",
+    surfaceTint: "#eff6ff",
+  },
+  {
+    id: "purple",
+    label: "Purple",
+    swatchColor: "#8b5cf6",
+    accent: "#ddd6fe",
+    accentBorder: "#c4b5fd",
+    surfaceTint: "#f5f3ff",
+  },
+  {
+    id: "slate",
+    label: "Slate",
+    swatchColor: "#64748b",
+    accent: "#e2e8f0",
+    accentBorder: "#cbd5e1",
+    surfaceTint: "#f8fafc",
+  },
+];
+
+export function resolvePreset(id: string | null | undefined): ColorPreset {
+  return THEME_PRESETS.find((p) => p.id === id) ?? THEME_PRESETS[0];
+}
+
+/**
+ * Applies the resolved theme to the document root as CSS custom properties,
+ * a `dark` class, and `data-theme-mode`/`data-color-scope` attributes. Pure
+ * DOM side effect — no IPC, no React — so it can be called both from the
+ * persisted-settings-driven useTheme hook and from live-preview UI code.
+ */
+export function applyTheme(
+  theme: ThemeMode,
+  colorPreset: string | null | undefined,
+  colorScope: ColorScope,
+  osDark: boolean,
+): void {
+  const root = document.documentElement;
+  const effectiveDark = theme === "dark" || (theme === "auto" && osDark);
+
+  root.classList.toggle("dark", effectiveDark);
+  root.dataset.themeMode = theme;
+
+  if (theme === "color") {
+    const preset = resolvePreset(colorPreset);
+    root.style.setProperty("--popmark-accent", preset.accent);
+    root.style.setProperty("--popmark-accent-border", preset.accentBorder);
+    root.style.setProperty("--popmark-surface-tint", preset.surfaceTint);
+    root.style.setProperty("--popmark-primary", preset.swatchColor);
+    root.dataset.colorScope = colorScope;
+  } else {
+    root.style.removeProperty("--popmark-accent");
+    root.style.removeProperty("--popmark-accent-border");
+    root.style.removeProperty("--popmark-surface-tint");
+    root.style.removeProperty("--popmark-primary");
+    delete root.dataset.colorScope;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a user-selectable appearance theme with four modes: Auto (follow OS light/dark, default), Light, Dark, and Color. Color is an independent theme where the user picks one of seven curated presets (Red, Orange, Yellow, Green, Blue, Purple, Slate) and a scope of either Title bar (soft-tints just the toolbar / Settings header) or Whole window (also washes the editing area and footer with a light tint). The setting applies to both the main editor window and the Settings window.
- Switch Tailwind's `dark:` variant from OS-media-query resolution to a class-based one (`@custom-variant dark`), so theme selection is explicit rather than purely OS-driven; the existing hand-written dark-mode CSS for Markdown rendering is converted to the same class-based scheme.
- Buttons and checkboxes (Settings "Save", the "Send to Clipboard" split button, checkboxes, the Markdown task-checkbox) adopt the selected preset as their primary UI accent color via a new `--popmark-primary` CSS variable, with hover/active/divider shades derived automatically via `color-mix()`.
- Give the Settings window an Overlay title bar matching the main window, so its custom header band is the actual colorable "title bar" rather than sitting below an unstylable native one, and fix a pre-existing capability gap that silently blocked `event.listen` and window dragging in that window.

## Test plan

- [x] `npm run check` (Biome + Rust fmt/clippy) and `npm run build` (tsc + vite) pass
- [ ] Auto follows OS light/dark and updates live when the OS appearance changes while the app is open
- [ ] Explicit Light/Dark override OS appearance, including Markdown link/code/Prism/hr/task-checkbox colors
- [ ] Color + Title bar scope tints only the toolbar/Settings header; editing area stays neutral
- [ ] Color + Whole window scope also washes the editing area, footer, and Settings body; verify in both rich and plain editor modes
- [ ] Preset swatch and scope changes live-preview instantly in the Settings window before Save; Cancel/Esc reverts the preview
- [ ] Settings window can be dragged and its theme stays in sync with the main window after Save